### PR TITLE
fix #57 [CoreBundle]: unite cms manager should not be used before aut…

### DIFF
--- a/src/Bundle/CoreBundle/Entity/ApiKey.php
+++ b/src/Bundle/CoreBundle/Entity/ApiKey.php
@@ -13,7 +13,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * APIKey
  *
  * @ORM\Table(name="api_key")
- * @ORM\Entity
+ * @ORM\Entity(repositoryClass="UniteCMS\CoreBundle\Repository\ApiKeyRepository")
  * @UniqueEntity(fields={"token", "organization"}, message="validation.token_present")
  * @UniqueEntity(fields={"name", "organization"}, message="validation.name_present")
  */

--- a/src/Bundle/CoreBundle/Exception/MissingOrganizationException.php
+++ b/src/Bundle/CoreBundle/Exception/MissingOrganizationException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: franzwilding
+ * Date: 04.05.18
+ * Time: 09:22
+ */
+
+namespace App\Bundle\CoreBundle\Exception;
+
+
+class MissingOrganizationException extends \Exception
+{
+
+}

--- a/src/Bundle/CoreBundle/Repository/ApiKeyRepository.php
+++ b/src/Bundle/CoreBundle/Repository/ApiKeyRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace UniteCMS\CoreBundle\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * ApiKeyRepository
+ */
+class ApiKeyRepository extends EntityRepository
+{
+    public function findOneByTokenAndOrganization(string $token, string $organization)
+    {
+        $result = $this->createQueryBuilder('a')
+            ->select('a')
+            ->join('a.organization', 'org')
+            ->where('a.token = :token')
+            ->andWhere('org.identifier = :organization')
+            ->setParameters(
+                [
+                    'token' => $token,
+                    'organization' => $organization,
+                ]
+            )
+            ->getQuery()->getResult();
+
+        return (count($result) > 0) ? $result[0] : null;
+    }
+}

--- a/src/Bundle/CoreBundle/Resources/config/services.security.yml
+++ b/src/Bundle/CoreBundle/Resources/config/services.security.yml
@@ -9,7 +9,7 @@ services:
 
   unite.cms.api_key_provider:
     class: UniteCMS\CoreBundle\Security\ApiKeyUserProvider
-    arguments: ['@unite.cms.manager', '@doctrine.orm.default_entity_manager']
+    arguments: ['@request_stack', '@doctrine.orm.default_entity_manager']
     public: false
 
   # We implement a custom RequestMatcher for the API firewall that also handles fallback to the main firewall if a

--- a/src/Bundle/CoreBundle/Tests/Service/UniteCMSManagerTest.php
+++ b/src/Bundle/CoreBundle/Tests/Service/UniteCMSManagerTest.php
@@ -9,7 +9,11 @@
 namespace UniteCMS\CoreBundle\Tests\Service;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Router;
+use UniteCMS\CoreBundle\Entity\ApiKey;
+use UniteCMS\CoreBundle\Entity\Content;
 use UniteCMS\CoreBundle\Entity\Domain;
+use UniteCMS\CoreBundle\Entity\DomainMember;
 use UniteCMS\CoreBundle\Entity\Organization;
 use UniteCMS\CoreBundle\Entity\OrganizationMember;
 use UniteCMS\CoreBundle\Entity\User;
@@ -40,7 +44,11 @@ class UniteCMSManagerTest extends DatabaseAwareTestCase
         "identifier": "ct1", 
         "fields": [
             { "title": "Field 1", "identifier": "f1", "type": "text" }, 
-            { "title": "Field 2", "identifier": "f2", "type": "text" }
+            { "title": "Field 2", "identifier": "f2", "type": "text" },
+            { "title": "Field 3", "identifier": "f3", "type": "reference", "settings": {
+                "domain": "unite_cms_manager",
+                "content_type": "ct1"
+            } }
         ], 
         "views": [
             { "title": "All", "identifier": "all", "type": "table" },


### PR DESCRIPTION
…hentication is done because this results in two instances of the service class