### PR TITLE
Feature/118 improve test performance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,23 +25,38 @@
     "repositories": [
         {
             "type": "path",
-            "url": "./src/Bundle/CoreBundle"
+            "url": "./src/Bundle/CoreBundle",
+            "options": {
+                "symlink": true
+            }
         },
         {
             "type": "path",
-            "url": "./src/Bundle/CollectionFieldBundle"
+            "url": "./src/Bundle/CollectionFieldBundle",
+            "options": {
+                "symlink": true
+            }
         },
         {
             "type": "path",
-            "url": "./src/Bundle/RegistrationBundle"
+            "url": "./src/Bundle/RegistrationBundle",
+            "options": {
+                "symlink": true
+            }
         },
         {
             "type": "path",
-            "url": "./src/Bundle/StorageBundle"
+            "url": "./src/Bundle/StorageBundle",
+            "options": {
+                "symlink": true
+            }
         },
         {
             "type": "path",
-            "url": "./src/Bundle/WysiwygFieldBundle"
+            "url": "./src/Bundle/WysiwygFieldBundle",
+            "options": {
+                "symlink": true
+            }
         }
     ],
     "require": {
@@ -49,10 +64,10 @@
         "unite-cms/collection-field-bundle": "0@dev",
         "unite-cms/registration-bundle": "0@dev",
         "unite-cms/storage-bundle": "0@dev",
-        "unite-cms/wysiwyg-field-bundle": "0@dev",
-        "doctrine/data-fixtures": "^1.3"
+        "unite-cms/wysiwyg-field-bundle": "0@dev"
     },
     "require-dev": {
+        "doctrine/data-fixtures": "^1.3",
         "symfony/thanks": "^1.0",
         "symfony/browser-kit": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "unite-cms/collection-field-bundle": "0@dev",
         "unite-cms/registration-bundle": "0@dev",
         "unite-cms/storage-bundle": "0@dev",
-        "unite-cms/wysiwyg-field-bundle": "0@dev"
+        "unite-cms/wysiwyg-field-bundle": "0@dev",
+        "doctrine/data-fixtures": "^1.3"
     },
     "require-dev": {
         "symfony/thanks": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,10 +25,6 @@
         <env name="MAILER_SENDER" value="unite@unite.co.at"/>
     </php>
 
-    <php>
-        <env name="BOOTSTRAP_CLEAR_CACHE_ENV" value="test" />
-    </php>
-
     <testsuites>
         <testsuite name="unite cms test cases">
             <directory>./src/Bundle/*/Tests/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="./src/TestBootstrap.php"
          failOnRisky="true"
          failOnWarning="true"
 >
@@ -23,6 +23,10 @@
         <env name="DATABASE_USER" value="root"/>
         <env name="DATABASE_PASSWORD" value=""/>
         <env name="MAILER_SENDER" value="unite@unite.co.at"/>
+    </php>
+
+    <php>
+        <env name="BOOTSTRAP_CLEAR_CACHE_ENV" value="test" />
     </php>
 
     <testsuites>

--- a/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
+++ b/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
@@ -4,6 +4,7 @@ namespace UniteCMS\CoreBundle\Tests;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 
 abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
 {
@@ -18,19 +19,29 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
         parent::setUp();
         $this->em = static::$container->get('doctrine')->getManager();
 
-        $schemaTool = new SchemaTool($this->em);
-        $metadata = $this->em->getMetadataFactory()->getAllMetadata();
-        $schemaTool->dropSchema($metadata);
-        $schemaTool->createSchema($metadata);
+        $this->purgeDatabase();
+
+        #$schemaTool = new SchemaTool($this->em);
+        #$metadata = $this->em->getMetadataFactory()->getAllMetadata();
+        #$schemaTool->dropSchema($metadata);
+        #$schemaTool->createSchema($metadata);
     }
 
     public function tearDown()
     {
-        $schemaTool = new SchemaTool($this->em);
-        $metadata = $this->em->getMetadataFactory()->getAllMetadata();
-        $schemaTool->dropSchema($metadata);
-        $this->em->getConnection()->close();
-        parent::tearDown();
-        $this->em = null;
+
+        $this->purgeDatabase();
+        #$schemaTool = new SchemaTool($this->em);
+        #$metadata = $this->em->getMetadataFactory()->getAllMetadata();
+        #$schemaTool->dropSchema($metadata);
+        #$this->em->getConnection()->close();
+        #parent::tearDown();
+        #$this->em = null;
+    }
+
+    private function purgeDatabase()
+    {
+        $purger = new ORMPurger($this->em);
+        $purger->purge();
     }
 }

--- a/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
+++ b/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
@@ -17,25 +17,31 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
     public function setUp()
     {
         parent::setUp();
+
         $this->em = static::$container->get('doctrine')->getManager();
+
+        $schema_manager = $this->em->getConnection()->getSchemaManager();
+
+        # create schema only if database is empty
+        if (!$schema_manager->tablesExist('content')) {
+            $schemaTool = new SchemaTool($this->em);
+            $metadata = $this->em->getMetadataFactory()->getAllMetadata();
+            $schemaTool->createSchema($metadata);
+        }
 
         $this->purgeDatabase();
 
-        #$schemaTool = new SchemaTool($this->em);
-        #$metadata = $this->em->getMetadataFactory()->getAllMetadata();
-        #$schemaTool->dropSchema($metadata);
-        #$schemaTool->createSchema($metadata);
     }
 
     public function tearDown()
     {
-
-        $this->purgeDatabase();
+        #$this->purgeDatabase();
         #$schemaTool = new SchemaTool($this->em);
         #$metadata = $this->em->getMetadataFactory()->getAllMetadata();
         #$schemaTool->dropSchema($metadata);
+        ##$this->purgeDatabase();
         #$this->em->getConnection()->close();
-        #parent::tearDown();
+        parent::tearDown();
         #$this->em = null;
     }
 
@@ -43,5 +49,12 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
     {
         $purger = new ORMPurger($this->em);
         $purger->purge();
+    }
+
+    public function recreateSchema() {
+        $schemaTool = new SchemaTool($this->em);
+        $metadata = $this->em->getMetadataFactory()->getAllMetadata();
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
     }
 }

--- a/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
+++ b/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
@@ -14,35 +14,37 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
      */
     protected $em;
 
+    protected $testStrategy = "purge";
+
     public function setUp()
     {
         parent::setUp();
 
         $this->em = static::$container->get('doctrine')->getManager();
 
-        $schema_manager = $this->em->getConnection()->getSchemaManager();
-
-        # create schema only if database is empty
-        if (!$schema_manager->tablesExist('content')) {
+        if ($this->testStrategy == "recreate") {
             $schemaTool = new SchemaTool($this->em);
             $metadata = $this->em->getMetadataFactory()->getAllMetadata();
+            $schemaTool->dropSchema($metadata);
             $schemaTool->createSchema($metadata);
         }
-
-        $this->purgeDatabase();
-
+        else {
+            $this->purgeDatabase();
+        }
     }
 
     public function tearDown()
     {
-        #$this->purgeDatabase();
-        #$schemaTool = new SchemaTool($this->em);
-        #$metadata = $this->em->getMetadataFactory()->getAllMetadata();
-        #$schemaTool->dropSchema($metadata);
-        ##$this->purgeDatabase();
-        #$this->em->getConnection()->close();
+        if ($this->testStrategy == "recreate") {
+            $this->purgeDatabase();
+            $this->em->getConnection()->close();
+        }
+        else {
+            $this->purgeDatabase();
+        }
+        $this->em->getConnection()->close();
         parent::tearDown();
-        #$this->em = null;
+        $this->em = null;
     }
 
     private function purgeDatabase()
@@ -51,10 +53,4 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
         $purger->purge();
     }
 
-    public function recreateSchema() {
-        $schemaTool = new SchemaTool($this->em);
-        $metadata = $this->em->getMetadataFactory()->getAllMetadata();
-        $schemaTool->dropSchema($metadata);
-        $schemaTool->createSchema($metadata);
-    }
 }

--- a/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
+++ b/src/Bundle/CoreBundle/Tests/DatabaseAwareTestCase.php
@@ -14,7 +14,7 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
      */
     protected $em;
 
-    protected $testStrategy = "purge";
+    protected $databaseStrategy = "STRATEGY_PURGE";
 
     public function setUp()
     {
@@ -22,7 +22,7 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
 
         $this->em = static::$container->get('doctrine')->getManager();
 
-        if ($this->testStrategy == "recreate") {
+        if ($this->databaseStrategy == "STRATEGY_RECREATE") {
             $schemaTool = new SchemaTool($this->em);
             $metadata = $this->em->getMetadataFactory()->getAllMetadata();
             $schemaTool->dropSchema($metadata);
@@ -35,7 +35,7 @@ abstract class DatabaseAwareTestCase extends ContainerAwareTestCase
 
     public function tearDown()
     {
-        if ($this->testStrategy == "recreate") {
+        if ($this->databaseStrategy == "STRATEGY_RECREATE") {
             $this->purgeDatabase();
             $this->em->getConnection()->close();
         }

--- a/src/Bundle/CoreBundle/Tests/Security/ControllerAccessCheckTest.php
+++ b/src/Bundle/CoreBundle/Tests/Security/ControllerAccessCheckTest.php
@@ -85,7 +85,7 @@ class ControllerAccessCheckTest extends DatabaseAwareTestCase
     ]
   }';
 
-    protected $testStrategy = "recreate";
+    protected $databaseStrategy = "STRATEGY_RECREATE";
 
     public function setUp()
     {

--- a/src/Bundle/CoreBundle/Tests/Security/ControllerAccessCheckTest.php
+++ b/src/Bundle/CoreBundle/Tests/Security/ControllerAccessCheckTest.php
@@ -85,7 +85,7 @@ class ControllerAccessCheckTest extends DatabaseAwareTestCase
     ]
   }';
 
-    protected $databaseStrategy = "STRATEGY_RECREATE";
+    protected $databaseStrategy = DatabaseAwareTestCase::STRATEGY_RECREATE;
 
     public function setUp()
     {

--- a/src/Bundle/CoreBundle/Tests/Security/ControllerAccessCheckTest.php
+++ b/src/Bundle/CoreBundle/Tests/Security/ControllerAccessCheckTest.php
@@ -85,6 +85,8 @@ class ControllerAccessCheckTest extends DatabaseAwareTestCase
     ]
   }';
 
+    protected $testStrategy = "recreate";
+
     public function setUp()
     {
         parent::setUp();

--- a/src/TestBootstrap.php
+++ b/src/TestBootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+if (isset($_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'])) {
+
+    passthru(sprintf(
+      'php "%s/../bin/console" doctrine:schema:drop --force',
+      __DIR__,
+      $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV']
+    ));
+
+    passthru(sprintf(
+      'php "%s/../bin/console" doctrine:schema:update --force',
+      __DIR__,
+      $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV']
+    ));
+
+    passthru(sprintf(
+      'php "%s/../bin/console" cache:clear --env=%s --no-warmup',
+      __DIR__,
+      $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV']
+    ));
+
+}
+
+require __DIR__.'/../vendor/autoload.php';

--- a/src/TestBootstrap.php
+++ b/src/TestBootstrap.php
@@ -1,23 +1,23 @@
 <?php
 
-if (isset($_ENV['BOOTSTRAP_CLEAR_CACHE_ENV'])) {
+if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] == "test") {
 
     passthru(sprintf(
-      'php "%s/../bin/console" doctrine:schema:drop --force',
+      'php "%s/../bin/console" doctrine:schema:drop --force --quiet',
       __DIR__,
-      $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV']
+      $_ENV['APP_ENV']
     ));
 
     passthru(sprintf(
-      'php "%s/../bin/console" doctrine:schema:update --force',
+      'php "%s/../bin/console" doctrine:schema:update --force --quiet',
       __DIR__,
-      $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV']
+      $_ENV['APP_ENV']
     ));
 
     passthru(sprintf(
-      'php "%s/../bin/console" cache:clear --env=%s --no-warmup',
+      'php "%s/../bin/console" cache:clear --env=%s --no-warmup --quiet',
       __DIR__,
-      $_ENV['BOOTSTRAP_CLEAR_CACHE_ENV']
+      $_ENV['APP_ENV']
     ));
 
 }


### PR DESCRIPTION
puh this is time consuming

My outcome until now:
refactoring all the tests is a lot of effort for little performance improvements

the biggest performance impact comes from dropping and recreating the schema for each test in DatabaseAwareTestCase

so here is another approach
create schema with bootstrap file before all tests
if certain tests need a schema drop & recreate, there is a $testStrategy variable 

There are 3 tests failing (registration bundle), but they do also fail in master branch
EDIT: maybe i'm missing some variable settings

Still missing:
ApiFunctionalTest::testAPIFiltering

Maybe we should discuss this