### PR TITLE
feature #193 [CoreBundle, CollectionFieldBundle, StorageBundle]: Add …

### DIFF
--- a/src/Bundle/CollectionFieldBundle/Tests/CollectionFieldTypeTest.php
+++ b/src/Bundle/CollectionFieldBundle/Tests/CollectionFieldTypeTest.php
@@ -352,6 +352,7 @@ class CollectionFieldTypeTest extends FieldTypeTestCase
             $schema,
             'mutation { 
       createCt1(
+        persist: true,
         data: {
           f1: [
             {},
@@ -484,6 +485,7 @@ class CollectionFieldTypeTest extends FieldTypeTestCase
             $schema,
             'mutation { 
       createCt1(
+        persist: true,
         data: {
           f1: [
             {},

--- a/src/Bundle/CoreBundle/SchemaType/Types/MutationType.php
+++ b/src/Bundle/CoreBundle/SchemaType/Types/MutationType.php
@@ -83,6 +83,12 @@ class MutationType extends AbstractType
 
             $fields['create' . $key] = [
                 'type' => $this->schemaTypeManager->getSchemaType($key . 'Content', $this->uniteCMSManager->getDomain()),
+                'args' => [
+                    'persist' => [
+                        'type' => Type::nonNull(Type::boolean()),
+                        'description' => 'Only if is set to true, the content will be created. Data will be validated anyway.',
+                    ],
+                ],
             ];
 
             $fields['update' . $key] = [
@@ -91,6 +97,10 @@ class MutationType extends AbstractType
                     'id' => [
                         'type' => Type::nonNull(Type::id()),
                         'description' => 'The id of the content item to get.',
+                    ],
+                    'persist' => [
+                        'type' => Type::nonNull(Type::boolean()),
+                        'description' => 'Only if is set to true, the content will be updated. Data will be validated anyway.',
                     ],
                 ],
             ];
@@ -209,8 +219,11 @@ class MutationType extends AbstractType
 
             // If content is valid.
             } else {
-                $this->entityManager->persist($content);
-                $this->entityManager->flush();
+
+                if($args['persist']) {
+                    $this->entityManager->persist($content);
+                    $this->entityManager->flush();
+                }
 
                 return $content;
             }
@@ -278,7 +291,11 @@ class MutationType extends AbstractType
 
             // If content is valid.
             } else {
-                $this->entityManager->flush();
+
+                if($args['persist']) {
+                    $this->entityManager->flush();
+                }
+
                 return $content;
             }
         }

--- a/src/Bundle/CoreBundle/Tests/Functional/ApiFunctionalTest.php
+++ b/src/Bundle/CoreBundle/Tests/Functional/ApiFunctionalTest.php
@@ -999,7 +999,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_viewer'], 'mutation {
-                createNews_category(data: { name: "First Category" }) {
+                createNews_category(data: { name: "First Category" }, persist: true) {
                     id, 
                     name
                 }
@@ -1008,17 +1008,36 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $this->assertNotEmpty($response->errors);
         $this->assertEquals("You are not allowed to create content in content type 'News Category'.", $response->errors[0]->message);
 
-        // Try to create content with permissions.
+        // Try to create content with permissions but do not persist.
+        $initialCount = $this->em->getRepository('UniteCMSCoreBundle:Content')->count([]);
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation {
-                createNews_category(data: { name: "First Category" }) {
+                createNews_category(data: { name: "First Category" }, persist: false) {
                     id, 
                     name
                 }
             }');
 
+        $this->assertEquals($initialCount, $this->em->getRepository('UniteCMSCoreBundle:Content')->count([]));
         $this->assertTrue(empty($response->errors));
+        $category = $response->data->createNews_category;
+        $this->assertEmpty($category->id);
+        $this->assertEquals('First Category', $category->name);
+
+        // Try to create content with permissions.
+        $response = $this->api(
+            $this->domains['marketing'],
+            $this->users['marketing_editor'], 'mutation {
+                createNews_category(data: { name: "First Category" }, persist: true) {
+                    id, 
+                    name
+                }
+            }');
+
+        $this->assertEquals($initialCount+1, $this->em->getRepository('UniteCMSCoreBundle:Content')->count([]));
+        $this->assertTrue(empty($response->errors));
+
         $category = $response->data->createNews_category;
         $this->assertEquals('First Category', $category->name);
         $this->assertNotEmpty($category->id);
@@ -1027,7 +1046,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($category: ReferenceFieldTypeInput) {
-                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category }) {
+                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category }, persist: true) {
                     id, 
                     title_title,
                     content,
@@ -1051,7 +1070,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($category: ReferenceFieldTypeInput) {
-                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category }) {
+                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category }, persist: true) {
                     id, 
                     title_title,
                     content,
@@ -1080,7 +1099,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_viewer'], 'mutation($id: ID!) {
-                updateNews_category(id: $id, data: { name: "Updated Category Title" }) {
+                updateNews_category(id: $id, data: { name: "Updated Category Title" }, persist: true) {
                     id, 
                     name
                 }
@@ -1093,7 +1112,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($id: ID!) {
-                updateNews_category(id: $id, data: { name: "Updated Category Title" }) {
+                updateNews_category(id: $id, data: { name: "Updated Category Title" }, persist: true) {
                     id, 
                     name
                 }
@@ -1109,7 +1128,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($id: ID!, $category: ReferenceFieldTypeInput) {
-                updateNews(id: $id, data: { title_title: "Updated News", content: "<p>Hello new World</p>", category: $category }) {
+                updateNews(id: $id, data: { title_title: "Updated News", content: "<p>Hello new World</p>", category: $category }, persist: true) {
                     id, 
                     title_title,
                     content,
@@ -1134,7 +1153,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($id: ID!, $category: ReferenceFieldTypeInput) {
-                updateNews(id: $id, data: { title_title: "Updated News", content: "<p>Hello new World</p>", category: $category }) {
+                updateNews(id: $id, data: { title_title: "Updated News", content: "<p>Hello new World</p>", category: $category }, persist: true) {
                     id, 
                     title_title,
                     content,
@@ -1158,7 +1177,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($id: ID!) {
-                updateNews(id: $id, data: { title_title: "Updated News2" }) {
+                updateNews(id: $id, data: { title_title: "Updated News2" }, persist: true) {
                     id, 
                     title_title,
                     content,
@@ -1220,7 +1239,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation {
-                createNews(data: { title_title: "First News" }) {
+                createNews(data: { title_title: "First News" }, persist: true) {
                     id, 
                     title_title
                 }
@@ -1233,7 +1252,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation {
-                createNews(data: { title_title: "First News" }) {
+                createNews(data: { title_title: "First News" }, persist: true) {
                     id, 
                     title_title
                 }
@@ -1246,7 +1265,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $responseUpdate = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($id: ID!) {
-                updateNews(id: $id, data: { title_title: "Updated News" }) { 
+                updateNews(id: $id, data: { title_title: "Updated News" }, persist: true) { 
                     title_title
                 }
             }', [
@@ -1259,7 +1278,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $responseUpdate = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($id: ID!) {
-                updateNews(id: $id, data: { title_title: "Updated News" }) { 
+                updateNews(id: $id, data: { title_title: "Updated News" }, persist: true) { 
                     title_title
                 }
             }', [

--- a/src/Bundle/StorageBundle/Tests/FileFieldTypeTest.php
+++ b/src/Bundle/StorageBundle/Tests/FileFieldTypeTest.php
@@ -229,6 +229,7 @@ class FileFieldTypeTest extends FieldTypeTestCase
             $schema,
             'mutation { 
       createCt1(
+        persist: true,
         data: {
           f1: {
             name: "cat.jpg",
@@ -262,6 +263,7 @@ class FileFieldTypeTest extends FieldTypeTestCase
             $schema,
             'mutation { 
       createCt1(
+        persist: true,
         data: {
           f1: {
             name: "cat.jpg",

--- a/src/Bundle/StorageBundle/Tests/ImageFieldTypeTest.php
+++ b/src/Bundle/StorageBundle/Tests/ImageFieldTypeTest.php
@@ -227,6 +227,7 @@ class ImageFieldTypeTest extends FieldTypeTestCase
             $schema,
             'mutation { 
       createCt1(
+        persist: true,
         data: {
           f1: {
             name: "cat.jpg",
@@ -260,6 +261,7 @@ class ImageFieldTypeTest extends FieldTypeTestCase
             $schema,
             'mutation { 
       createCt1(
+        persist: true,
         data: {
           f1: {
             name: "cat.jpg",


### PR DESCRIPTION
…a persist option to content mutation calls