### PR TITLE
fix #191 [CoreBundle]: as domain member types are flexible, all domai…

### DIFF
--- a/src/Bundle/CoreBundle/Entity/DomainAccessor.php
+++ b/src/Bundle/CoreBundle/Entity/DomainAccessor.php
@@ -111,7 +111,7 @@ abstract class DomainAccessor
      * Returns all matching domain memberships of this user for the given domain or null if this user is not member of the domain.
      *
      * @param Domain $domain
-     * @return DomainMember[]|null
+     * @return DomainMember[]
      */
     public function getDomainMembers(Domain $domain)
     {
@@ -122,11 +122,7 @@ abstract class DomainAccessor
             }
         }
 
-        if (count($domainMembers) > 0) {
-            return $domainMembers;
-        }
-
-        return null;
+        return $domainMembers;
     }
 
     /**

--- a/src/Bundle/CoreBundle/Entity/DomainAccessor.php
+++ b/src/Bundle/CoreBundle/Entity/DomainAccessor.php
@@ -113,7 +113,7 @@ abstract class DomainAccessor
      * @param Domain $domain
      * @return DomainMember[]
      */
-    public function getDomainMembers(Domain $domain)
+    public function getDomainMembers(Domain $domain): array
     {
         $domainMembers = [];
         foreach ($this->getDomains() as $domainMember) {

--- a/src/Bundle/CoreBundle/Entity/DomainAccessor.php
+++ b/src/Bundle/CoreBundle/Entity/DomainAccessor.php
@@ -108,17 +108,22 @@ abstract class DomainAccessor
     }
 
     /**
-     * Returns the domain membership of this user for the given domain or null if this user is not member of the domain.
+     * Returns all matching domain memberships of this user for the given domain or null if this user is not member of the domain.
      *
      * @param Domain $domain
-     * @return DomainMember|null
+     * @return DomainMember[]|null
      */
-    public function getDomainMember(Domain $domain)
+    public function getDomainMembers(Domain $domain)
     {
+        $domainMembers = [];
         foreach ($this->getDomains() as $domainMember) {
             if (!empty($domain->getId()) && $domainMember->getDomain()->getId() === $domain->getId()) {
-                return $domainMember;
+                $domainMembers[] = $domainMember;
             }
+        }
+
+        if (count($domainMembers) > 0) {
+            return $domainMembers;
         }
 
         return null;

--- a/src/Bundle/CoreBundle/Security/Voter/ContentVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/ContentVoter.php
@@ -78,7 +78,7 @@ class ContentVoter extends Voter
             return self::ACCESS_ABSTAIN;
         }
 
-        $domainMember = $token->getUser()->getDomainMember($contentType->getDomain());
+        $domainMembers = $token->getUser()->getDomainMembers($contentType->getDomain());
 
         // Only work for non-deleted content
         if ($subject instanceof Content && $subject->getDeleted() != null) {
@@ -86,7 +86,7 @@ class ContentVoter extends Voter
         }
 
         // We can only vote if this user is member of the subject's domain.
-        if(!$domainMember) {
+        if(!$domainMembers) {
             return self::ACCESS_ABSTAIN;
         }
 
@@ -96,8 +96,10 @@ class ContentVoter extends Voter
         }
 
         // If the expression evaluates to true, we grant access.
-        if($this->accessExpressionChecker->evaluate($contentType->getPermissions()[$attribute], $domainMember, $subject instanceof Content ? $subject : null)) {
-            return self::ACCESS_GRANTED;
+        foreach ($domainMembers as $domainMember) {
+            if($this->accessExpressionChecker->evaluate($contentType->getPermissions()[$attribute], $domainMember, $subject instanceof Content ? $subject : null)) {
+                return self::ACCESS_GRANTED;
+            }
         }
 
         return self::ACCESS_ABSTAIN;

--- a/src/Bundle/CoreBundle/Security/Voter/ContentVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/ContentVoter.php
@@ -85,11 +85,6 @@ class ContentVoter extends Voter
             return self::ACCESS_ABSTAIN;
         }
 
-        // We can only vote if this user is member of the subject's domain.
-        if(!$domainMembers) {
-            return self::ACCESS_ABSTAIN;
-        }
-
         // If the requested permission is not defined, throw an exception.
         if (empty($contentType->getPermissions()[$attribute])) {
             throw new \InvalidArgumentException("Permission '$attribute' was not found in ContentType '$contentType'");

--- a/src/Bundle/CoreBundle/Security/Voter/DeletedContentVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/DeletedContentVoter.php
@@ -52,7 +52,7 @@ class DeletedContentVoter extends ContentVoter
             return self::ACCESS_ABSTAIN;
         }
 
-        $domainMember = $token->getUser()->getDomainMember($contentType->getDomain());
+        $domainMembers = $token->getUser()->getDomainMembers($contentType->getDomain());
 
         // Only work for non-deleted content
         if ($subject->getDeleted() == null) {
@@ -60,7 +60,7 @@ class DeletedContentVoter extends ContentVoter
         }
 
         // We can only vote if this user is member of the subject's domain.
-        if(!$domainMember) {
+        if(!$domainMembers) {
             return self::ACCESS_ABSTAIN;
         }
 
@@ -75,8 +75,10 @@ class DeletedContentVoter extends ContentVoter
         }
 
         // If the expression evaluates to true, we grant access.
-        if($this->accessExpressionChecker->evaluate($contentType->getPermissions()[$attribute], $domainMember, $subject instanceof Content ? $subject : null)) {
-            return self::ACCESS_GRANTED;
+        foreach ($domainMembers as $domainMember) {
+            if($this->accessExpressionChecker->evaluate($contentType->getPermissions()[$attribute], $domainMember, $subject instanceof Content ? $subject : null)) {
+                return self::ACCESS_GRANTED;
+            }
         }
 
         return self::ACCESS_ABSTAIN;

--- a/src/Bundle/CoreBundle/Security/Voter/DeletedContentVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/DeletedContentVoter.php
@@ -59,11 +59,6 @@ class DeletedContentVoter extends ContentVoter
             return self::ACCESS_ABSTAIN;
         }
 
-        // We can only vote if this user is member of the subject's domain.
-        if(!$domainMembers) {
-            return self::ACCESS_ABSTAIN;
-        }
-
         // If the requested permission is not defined, throw an exception.
         if (empty($contentType->getPermissions()[$attribute])) {
             throw new \InvalidArgumentException("Permission '$attribute' was not found in ContentType '$contentType'");

--- a/src/Bundle/CoreBundle/Security/Voter/DomainVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/DomainVoter.php
@@ -90,11 +90,6 @@ class DomainVoter extends Voter
 
             $domainMembers = $user->getDomainMembers($subject);
 
-            // We can only vote if this user is member of the domain.
-            if(!$domainMembers) {
-                return self::ACCESS_ABSTAIN;
-            }
-
             // If the requested permission is not defined, throw an exception.
             if (empty($subject->getPermissions()[$attribute])) {
                 throw new \InvalidArgumentException("Permission '$attribute' was not found in domain '$subject'");

--- a/src/Bundle/CoreBundle/Security/Voter/DomainVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/DomainVoter.php
@@ -88,10 +88,10 @@ class DomainVoter extends Voter
 
         if($subject instanceof Domain) {
 
-            $domainMember = $user->getDomainMember($subject);
+            $domainMembers = $user->getDomainMembers($subject);
 
             // We can only vote if this user is member of the domain.
-            if(!$domainMember) {
+            if(!$domainMembers) {
                 return self::ACCESS_ABSTAIN;
             }
 
@@ -101,8 +101,10 @@ class DomainVoter extends Voter
             }
 
             // If the expression evaluates to true, we grant access.
-            if($this->accessExpressionChecker->evaluate($subject->getPermissions()[$attribute], $domainMember)) {
-                return self::ACCESS_GRANTED;
+            foreach ($domainMembers as $domainMember) {
+                if($this->accessExpressionChecker->evaluate($subject->getPermissions()[$attribute], $domainMember)) {
+                    return self::ACCESS_GRANTED;
+                }
             }
         }
 

--- a/src/Bundle/CoreBundle/Security/Voter/SettingVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/SettingVoter.php
@@ -72,10 +72,10 @@ class SettingVoter extends Voter
             return self::ACCESS_ABSTAIN;
         }
 
-        $domainMember = $token->getUser()->getDomainMember($settingType->getDomain());
+        $domainMembers = $token->getUser()->getDomainMembers($settingType->getDomain());
 
         // We can only vote if this user is member of the subject's domain.
-        if(!$domainMember) {
+        if(!$domainMembers) {
             return self::ACCESS_ABSTAIN;
         }
 
@@ -85,8 +85,10 @@ class SettingVoter extends Voter
         }
 
         // If the expression evaluates to true, we grant access.
-        if($this->accessExpressionChecker->evaluate($settingType->getPermissions()[$attribute], $domainMember, $subject instanceof Setting ? $subject : $settingType->getSetting())) {
-            return self::ACCESS_GRANTED;
+        foreach ($domainMembers as $domainMember) {
+            if($this->accessExpressionChecker->evaluate($settingType->getPermissions()[$attribute], $domainMember, $subject instanceof Setting ? $subject : $settingType->getSetting())) {
+                return self::ACCESS_GRANTED;
+            }
         }
 
         return self::ACCESS_ABSTAIN;

--- a/src/Bundle/CoreBundle/Security/Voter/SettingVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/SettingVoter.php
@@ -74,11 +74,6 @@ class SettingVoter extends Voter
 
         $domainMembers = $token->getUser()->getDomainMembers($settingType->getDomain());
 
-        // We can only vote if this user is member of the subject's domain.
-        if(!$domainMembers) {
-            return self::ACCESS_ABSTAIN;
-        }
-
         // If the requested permission is not defined, throw an exception.
         if (empty($settingType->getPermissions()[$attribute])) {
             throw new \InvalidArgumentException("Permission '$attribute' was not found in SettingType '$settingType'");

--- a/src/Bundle/CoreBundle/Tests/Controller/ContentControllerTest.php
+++ b/src/Bundle/CoreBundle/Tests/Controller/ContentControllerTest.php
@@ -101,10 +101,16 @@ class ContentControllerTest extends DatabaseAwareTestCase {
         $this->editor->setEmail('editor@example.com')->setName('Domain Editor')->setRoles([User::ROLE_USER])->setPassword('XXX');
         $domainEditorOrgMember = new OrganizationMember();
         $domainEditorOrgMember->setOrganization($this->organization);
-        $domainEditorDomainMember = new DomainMember();
-        $domainEditorDomainMember->setDomain($this->domain)->setDomainMemberType($this->domain->getDomainMemberTypes()->get('editor'));
+
+        $domainEditorDomainMemberViewer = new DomainMember();
+        $domainEditorDomainMemberViewer->setDomain($this->domain)->setDomainMemberType($this->domain->getDomainMemberTypes()->get('viewer'));
+
+        $domainEditorDomainMemberEditor = new DomainMember();
+        $domainEditorDomainMemberEditor->setDomain($this->domain)->setDomainMemberType($this->domain->getDomainMemberTypes()->get('editor'));
+
         $this->editor->addOrganization($domainEditorOrgMember);
-        $this->editor->addDomain($domainEditorDomainMember);
+        $this->editor->addDomain($domainEditorDomainMemberViewer);
+        $this->editor->addDomain($domainEditorDomainMemberEditor);
 
         $this->em->persist($this->editor);
 


### PR DESCRIPTION
…n member types have to be checked, not only the first matching one