### PR TITLE
fix #269 [CoreBundle]: Fix platform admin voter: entites can also be …

### DIFF
--- a/src/Bundle/CoreBundle/Security/Voter/PlatformAdminVoter.php
+++ b/src/Bundle/CoreBundle/Security/Voter/PlatformAdminVoter.php
@@ -20,6 +20,15 @@ use UniteCMS\CoreBundle\Entity\User;
 
 class PlatformAdminVoter extends Voter
 {
+    const SUPPORTED_OBJECTS = [
+        Organization::class,
+        Domain::class,
+        SettingType::class,
+        ContentType::class,
+        Setting::class,
+        Content::class,
+    ];
+
     /**
      * The platform admin voter supports all subjects.
      *
@@ -34,14 +43,14 @@ class PlatformAdminVoter extends Voter
             $subject = get_class($subject);
         }
 
-        return in_array($subject, [
-            Organization::class,
-            Domain::class,
-            SettingType::class,
-            ContentType::class,
-            Setting::class,
-            Content::class,
-        ]);
+        if(!empty($subject)) {
+            foreach(self::SUPPORTED_OBJECTS as $class) {
+                if(is_a($subject, $class, true)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
…doctrine proxy objects. So we should use is_a instead of in_array