### PR TITLE
fix #360 [CollectionFieldBundle]: Collection fields should dump all a…

### DIFF
--- a/src/Bundle/CollectionFieldBundle/Resources/views/Form/form_widgets.html.twig
+++ b/src/Bundle/CollectionFieldBundle/Resources/views/Form/form_widgets.html.twig
@@ -1,4 +1,5 @@
 {%- block unite_cms_collection_widget -%}
+    {{ include('@UniteCMSCore/Form/_recursive_asset_dumper.html.twig', { form: form }) }}
     {% if prototype is defined %}
         {%- set attr = attr|merge({'data-prototype': form_row(prototype) }) -%}
     {% endif %}


### PR DESCRIPTION
…ssets from child from fields at the beginning because javascript files wont get loaded when injected during row add