### PR TITLE
fix #375 [CoreBundle]: Type can also be null, this change will throw …

### DIFF
--- a/src/Bundle/CoreBundle/Entity/View.php
+++ b/src/Bundle/CoreBundle/Entity/View.php
@@ -219,7 +219,7 @@ class View
      *
      * @return View
      */
-    public function setType(string $type)
+    public function setType($type)
     {
         $this->type = $type;
 


### PR DESCRIPTION
…an validation error instead of an exception if type is missing