### PR TITLE
fix #387 [CoreBundle]: When referencing to the current domain, use th…

### DIFF
--- a/src/Bundle/CoreBundle/Entity/Domain.php
+++ b/src/Bundle/CoreBundle/Entity/Domain.php
@@ -132,6 +132,12 @@ class Domain
     private $config;
 
     /**
+     * When updating a domain, this variable can hold the previous identifier during the current request.
+     * @var string
+     */
+    private $previousIdentifier = null;
+
+    /**
      * If the config has changed, this variable is set to true to force an update.
      *
      * @var bool
@@ -444,6 +450,10 @@ class Domain
      */
     public function setIdentifier($identifier)
     {
+        if(!empty($this->identifier) && $identifier !== $this->identifier) {
+            $this->setPreviousIdentifier($this->identifier);
+        }
+
         $this->identifier = $identifier;
 
         return $this;
@@ -751,6 +761,24 @@ class Domain
      */
     public function setConfigChanged($changed = true) {
         $this->configChanged = $changed;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPreviousIdentifier()
+    {
+        return $this->previousIdentifier;
+    }
+
+    /**
+     * @param string $previousIdentifier
+     * @return Domain
+     */
+    public function setPreviousIdentifier(string $previousIdentifier)
+    {
+        $this->previousIdentifier = $previousIdentifier;
+        return $this;
     }
 }
 

--- a/src/Bundle/CoreBundle/Field/Types/ReferenceOfFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/ReferenceOfFieldType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 use UniteCMS\CoreBundle\Entity\Content;
 use UniteCMS\CoreBundle\Entity\ContentType;
 use UniteCMS\CoreBundle\Entity\ContentTypeField;
+use UniteCMS\CoreBundle\Entity\Domain;
 use UniteCMS\CoreBundle\Entity\FieldableContent;
 use UniteCMS\CoreBundle\Entity\FieldableField;
 use UniteCMS\CoreBundle\Exception\DomainAccessDeniedException;
@@ -123,7 +124,7 @@ class ReferenceOfFieldType extends FieldType
             $thisContentType = $context->getObject()->getContentType();
 
             // Check if field references the current content type.
-            if($field->getSettings()->domain !== $thisContentType->getDomain()->getIdentifier() || $field->getSettings()->content_type !== $thisContentType->getIdentifier()) {
+            if(($field->getSettings()->domain !== $thisContentType->getDomain()->getIdentifier() && $field->getSettings()->domain !== $thisContentType->getDomain()->getPreviousIdentifier()) || $field->getSettings()->content_type !== $thisContentType->getIdentifier()) {
                 $context->buildViolation('invalid_field_reference')->atPath('reference_field')->addViolation();
             }
 

--- a/src/Bundle/CoreBundle/Form/FieldExceptionFormType.php
+++ b/src/Bundle/CoreBundle/Form/FieldExceptionFormType.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: franzwilding
+ * Date: 2018-11-30
+ * Time: 13:31
+ */
+
+namespace UniteCMS\CoreBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+
+class FieldExceptionFormType extends AbstractType
+{
+    public function getBlockPrefix()
+    {
+        return 'unite_cms_core_field_exception';
+    }
+}

--- a/src/Bundle/CoreBundle/Form/FieldableFormType.php
+++ b/src/Bundle/CoreBundle/Form/FieldableFormType.php
@@ -46,11 +46,18 @@ class FieldableFormType extends AbstractType
          * @var FieldableFormField $field
          */
         foreach ($options['fields'] as $field) {
-            $builder->add(
-                $field->getFieldType()->getIdentifier($field->getFieldDefinition()),
-                $field->getFieldType()->getFormType($field->getFieldDefinition()),
-                $field->getFieldType()->getFormOptions($field->getFieldDefinition())
-            );
+            try {
+                $builder->add(
+                    $field->getFieldType()->getIdentifier($field->getFieldDefinition()),
+                    $field->getFieldType()->getFormType($field->getFieldDefinition()),
+                    $field->getFieldType()->getFormOptions($field->getFieldDefinition())
+                );
+            } catch (\Exception $e) {
+                $builder->add(
+                    $field->getFieldType()->getIdentifier($field->getFieldDefinition()),
+                    FieldExceptionFormType::class
+                );
+            }
         }
     }
 

--- a/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
+++ b/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
@@ -214,3 +214,7 @@
         to-label="{% trans %}state.field.to_label{% endtrans %}"
     ></unite-cms-core-state-field>
 {%- endblock unite_cms_core_state_widget -%}
+
+{%- block unite_cms_core_field_exception_widget %}
+    <div class="uk-alert-danger" uk-alert>There was a problem rendering this field. Please check the domain configuration or ask an administrator.</div>
+{%- endblock unite_cms_core_field_exception_widget -%}

--- a/src/Bundle/CoreBundle/Tests/Field/ReferenceFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/ReferenceFieldTypeTest.php
@@ -202,10 +202,6 @@ class ReferenceFieldTypeTest extends FieldTypeTestCase
         $o01->setAccessible(true);
         $referenceResolver = $o01->getValue($fieldType);
 
-        $o01 = new \ReflectionProperty($fieldType, 'referenceResolver');
-        $o01->setAccessible(true);
-        $referenceResolver = $o01->getValue($fieldType);
-
         $o1 = new \ReflectionProperty($referenceResolver, 'authorizationChecker');
         $o1->setAccessible(true);
         $authMock =  $this->createMock(AuthorizationCheckerInterface::class);
@@ -240,6 +236,12 @@ class ReferenceFieldTypeTest extends FieldTypeTestCase
 
         $errors = static::$container->get('validator')->validate($ctField);
         $this->assertCount(0, $errors);
+
+        // Now, when I change the domain identifier, the same settings should not be valid anymore.
+        $ctField->getContentType()->getDomain()->setIdentifier($ctField->getContentType()->getDomain()->getIdentifier() . '_updated');
+        $errors = static::$container->get('validator')->validate($ctField);
+        $this->assertCount(1, $errors);
+        $this->assertEquals('Invalid Domain given. The Domain does not exist or Access is prohibited', $errors->get(0)->getMessage());
     }
 
     public function testFormOptionGeneration() {

--- a/src/Bundle/CoreBundle/composer.json
+++ b/src/Bundle/CoreBundle/composer.json
@@ -3,7 +3,7 @@
     "type": "symfony-bundle",
     "description": "Core functionality for unite cms",
     "require": {
-        "symfony/symfony": "^4.1",
+        "symfony/symfony": "4.1.*",
         "doctrine/doctrine-bundle": "^1.9",
         "doctrine/orm": "^2.6",
         "jms/serializer-bundle": "^2.4",
@@ -16,12 +16,12 @@
         "webonyx/graphql-php": "^0.12",
         "symfony/swiftmailer-bundle": "^3.2",
         "oro/doctrine-extensions": "^1.2",
-        "symfony/expression-language": "^4.1"
+        "symfony/expression-language": "4.1.*"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3",
-        "symfony/phpunit-bridge": "^4.1",
-        "symfony/console": "^4.1"
+        "symfony/phpunit-bridge": "4.1.*",
+        "symfony/console": "4.1.*"
     },
     "autoload": {
         "psr-4": { "UniteCMS\\CoreBundle\\": "" },


### PR DESCRIPTION
…e root context instead of the persisted object to avoid identifier update conflicts. Also disable form field if exception was thrown instead of showing a 500er error