### PR TITLE
fix #459 [CoreBundle]: Add a violation cause to not_empty form errors…

### DIFF
--- a/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
+++ b/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
@@ -18,9 +18,17 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\ConstraintViolation;
 
 class UniteCMSCoreTypeExtension extends AbstractTypeExtension
 {
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
 
     /**
      * {@inheritdoc}
@@ -31,7 +39,15 @@ class UniteCMSCoreTypeExtension extends AbstractTypeExtension
         if (isset($options['not_empty']) && $options['not_empty']) {
             $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
                 if($event->getForm()->isEmpty()) {
-                    $event->getForm()->addError(new FormError('This value should not be blank.'));
+                    $error = new FormError($this->translator->trans('not_blank', [], 'validators'), null, [], null, new ConstraintViolation(
+                        $this->translator->trans('not_blank', [], 'validators'),
+                        null,
+                        [],
+                        null,
+                        'data'.$event->getForm()->getPropertyPath(),
+                        ''
+                    ));
+                    $event->getForm()->addError($error);
                 }
             });
         }

--- a/src/Bundle/CoreBundle/Resources/config/services.core.yml
+++ b/src/Bundle/CoreBundle/Resources/config/services.core.yml
@@ -91,5 +91,6 @@ services:
   # register unite core field type extension
   unite.cms.core_type_extension:
     class: UniteCMS\CoreBundle\Form\Extension\UniteCMSCoreTypeExtension
+    arguments: ['@translator']
     tags:
     - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }

--- a/src/Bundle/CoreBundle/Tests/Field/TextFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/TextFieldTypeTest.php
@@ -95,7 +95,7 @@ class TextFieldTypeTest extends FieldTypeTestCase
         $form->submit([]);
         $this->assertTrue($form->isSubmitted());
         $this->assertFalse($form->isValid());
-        $this->assertEquals('This value should not be blank.', $form->getErrors(true, true)->offsetGet(0)->getMessage());
+        $this->assertEquals(static::$container->get('translator')->trans('not_blank', [], 'validators'), $form->getErrors(true, true)->offsetGet(0)->getMessage());
 
         $form = static::$container->get('unite.cms.fieldable_form_builder')->createForm(
             $ctField->getContentType(),
@@ -111,7 +111,7 @@ class TextFieldTypeTest extends FieldTypeTestCase
         );
         $this->assertTrue($form->isSubmitted());
         $this->assertFalse($form->isValid());
-        $this->assertEquals('This value should not be blank.', $form->getErrors(true, true)->offsetGet(0)->getMessage());
+        $this->assertEquals(static::$container->get('translator')->trans('not_blank', [], 'validators'), $form->getErrors(true, true)->offsetGet(0)->getMessage());
 
         $form = static::$container->get('unite.cms.fieldable_form_builder')->createForm(
             $ctField->getContentType(),

--- a/src/Bundle/CoreBundle/Tests/Form/Extension/UniteCMSCoreTypeExtensionTest.php
+++ b/src/Bundle/CoreBundle/Tests/Form/Extension/UniteCMSCoreTypeExtensionTest.php
@@ -11,6 +11,7 @@ namespace UniteCMS\CoreBundle\Tests\Form\Extension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Translation\TranslatorInterface;
 use UniteCMS\CoreBundle\Form\Extension\UniteCMSCoreTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -24,7 +25,7 @@ class UniteCMSCoreTypeExtensionTest extends TypeTestCase
     protected function getTypeExtensions()
     {
         return array(
-            new UniteCMSCoreTypeExtension()
+            new UniteCMSCoreTypeExtension($this->createMock(TranslatorInterface::class))
         );
     }
 
@@ -50,7 +51,7 @@ class UniteCMSCoreTypeExtensionTest extends TypeTestCase
 
         // test if description is in form vars
         $form = $this->createMock(Form::class);
-        $formExtension = new UniteCMSCoreTypeExtension();
+        $formExtension = new UniteCMSCoreTypeExtension($this->createMock(TranslatorInterface::class));
         $formView = new FormView();
         $formExtension->buildView(
             $formView,

--- a/src/Bundle/CoreBundle/Tests/Functional/ApiFunctionalTest.php
+++ b/src/Bundle/CoreBundle/Tests/Functional/ApiFunctionalTest.php
@@ -68,6 +68,14 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
             "domain": "marketing",
             "content_type": "news_category"
           }
+        },
+        {
+          "title": "Not Empty",
+          "identifier": "not_empty",
+          "type": "text",
+          "settings": {
+            "not_empty": true
+          }
         }
       ],
       "views": [
@@ -1076,7 +1084,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($category: ReferenceFieldTypeInput) {
-                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category }, persist: true) {
+                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category, not_empty: "" }, persist: true) {
                     id, 
                     title_title,
                     content,
@@ -1094,6 +1102,30 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
             ]);
 
         $this->assertNotEmpty($response->errors);
+        $this->assertEquals(static::$container->get('translator')->trans('not_blank', [], 'validators'), $response->errors[0]->message);
+        $this->assertEquals(['createNews', 'data', 'not_empty'], $response->errors[0]->path);
+
+        $response = $this->api(
+            $this->domains['marketing'],
+            $this->users['marketing_editor'], 'mutation($category: ReferenceFieldTypeInput) {
+                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category, not_empty: "Foo" }, persist: true) {
+                    id, 
+                    title_title,
+                    content,
+                    category {
+                      id,
+                      name
+                    }
+                }
+            }', [
+            'category' => [
+                'domain' => 'marketing',
+                'content_type' => 'news_category',
+                'content' => 'foo',
+            ]
+        ]);
+
+        $this->assertNotEmpty($response->errors);
         $this->assertEquals(static::$container->get('translator')->trans('invalid_reference_definition', [], 'validators'), $response->errors[0]->message);
         $this->assertEquals(['createNews', 'data', 'category'], $response->errors[0]->path);
 
@@ -1101,7 +1133,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation($category: ReferenceFieldTypeInput) {
-                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category }, persist: true) {
+                createNews(data: { title_title: "First News", content: "<p>Hello World</p>", category: $category, not_empty: "FOO" }, persist: true) {
                     id, 
                     title_title,
                     content,
@@ -1501,7 +1533,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation {
-                createNews(data: { title_title: "First News" }, persist: true) {
+                createNews(data: { title_title: "First News", not_empty: "Foo" }, persist: true) {
                     id, 
                     title_title
                 }
@@ -1515,7 +1547,7 @@ class ApiFunctionalTestCase extends DatabaseAwareTestCase
         $response = $this->api(
             $this->domains['marketing'],
             $this->users['marketing_editor'], 'mutation {
-                createNews(data: { title_title: "First News" }, persist: true) {
+                createNews(data: { title_title: "First News", not_empty: "Foo" }, persist: true) {
                     id, 
                     title_title
                 }


### PR DESCRIPTION
…, so api error mapping will work