### PR TITLE
fix #476 [CoreBundle]: core requires guzzle. Guzzle was required only…

### DIFF
--- a/src/Bundle/CoreBundle/composer.json
+++ b/src/Bundle/CoreBundle/composer.json
@@ -17,7 +17,8 @@
         "symfony/swiftmailer-bundle": "^3.2",
         "oro/doctrine-extensions": "^1.2",
         "symfony/expression-language": "^4.2",
-        "cocur/slugify": "^3.1"
+        "cocur/slugify": "^3.1",
+        "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3",


### PR DESCRIPTION
… by storage bundle before, but core can also be used without storage bundle