### PR TITLE
fix #505 [StorageBundle]: Fix deleting objects from S3

### DIFF
--- a/src/Bundle/StorageBundle/Service/StorageService.php
+++ b/src/Bundle/StorageBundle/Service/StorageService.php
@@ -209,7 +209,7 @@ class StorageService
         $s3Client = new S3Client(
             [
                 'version' => 'latest',
-                'region' => 'us-east-1',
+                'region' => $bucket_settings['region'] ?? 'us-east-1',
                 'endpoint' => $bucket_settings['endpoint'],
                 'use_path_style_endpoint' => true,
                 'credentials' => [


### PR DESCRIPTION
The UniteCMS\StorageBundle\Service\StorageService::deleteObject method
always used the us-east-1 region when initialising an S3Client object.
This meant that delete operations on buckets in any other region would
fail.

This commit changes the method to use $bucket_settings['region'] and
only fall back to us-east-1 if it's not set, allowing deletes to work.