### PR TITLE
re #407 Add read_only field setting

### DIFF
--- a/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
+++ b/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
@@ -25,7 +25,7 @@ class CollectionFieldType extends FieldType implements NestableFieldTypeInterfac
 {
     const TYPE                      = "collection";
     const FORM_TYPE                 = CollectionFormType::class;
-    const SETTINGS                  = ['description', 'fields', 'min_rows', 'max_rows'];
+    const SETTINGS                  = ['description', 'fields', 'min_rows', 'max_rows', 'read_only'];
     const REQUIRED_SETTINGS         = ['fields'];
 
     private $collectionFieldTypeFactory;
@@ -66,8 +66,8 @@ class CollectionFieldType extends FieldType implements NestableFieldTypeInterfac
             parent::getFormOptions($field),
             [
                 'required' => true,         // Please see CollectionFormType::buildView() for more information.
-                'allow_add' => true,
-                'allow_delete' => true,
+                'allow_add' => !($settings->read_only ?? false),
+                'allow_delete' => !($settings->read_only ?? false),
                 'delete_empty' => true,
                 'error_bubbling' => false,
                 'prototype_name' => '__'.str_replace('/', '', ucwords($collection->getIdentifierPath(), '/')).'Name__',
@@ -75,6 +75,7 @@ class CollectionFieldType extends FieldType implements NestableFieldTypeInterfac
                     'data-identifier' => str_replace('/', '', ucwords($collection->getIdentifierPath(), '/')),
                     'min-rows' => $settings->min_rows ?? 0,
                     'max-rows' => $settings->max_rows ?? null,
+                    'read-only' => $settings->read_only ?? false,
                 ],
                 'entry_type' => FieldableFormType::class,
                 'entry_options' => $options,

--- a/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/Collection.vue
+++ b/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/Collection.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div :class="{ 'uk-background-muted': readOnly }">
         <div class="collection-wrapper">
             <unite-cms-collection-field-row
                     v-for="row in sortedRows"
@@ -8,11 +8,12 @@
                     :prototype="row.prototype"
                     :form-layout="rowFormLayout"
                     :hide-labels="rowLabelHidden"
+                    :read-only="readOnly"
                     @remove="removeRow"
                     @add="addRow"
             ></unite-cms-collection-field-row>
         </div>
-        <div v-if="!maxRows || rows.length < maxRows" class="collection-add-button-wrapper uk-sortable-nodrag">
+        <div v-if="!readOnly && (!maxRows || rows.length < maxRows)" class="collection-add-button-wrapper uk-sortable-nodrag">
             <button  class="uk-button uk-button-default" v-on:click.prevent="addRow" v-html="feather.icons['plus'].toSvg({ width: 20, height: 20 })"></button>
         </div>
     </div>
@@ -61,6 +62,7 @@
             'initRows',
             'minRows',
             'maxRows',
+            'readOnly',
             'labelLayout',
             'dataPrototype',
             'dataIdentifier'
@@ -102,7 +104,7 @@
                 return this.dataPrototype.replace(new RegExp('__' + this.dataIdentifier + 'Name__', 'g'), (delta));
             },
             addRow(event) {
-                if(!this.maxRows || this.rows.length < this.maxRows) {
+                if(!this.readOnly && (!this.maxRows || this.rows.length < this.maxRows)) {
 
                     let position = (event && event.detail && event.detail[0] && event.detail[0].delta !== null) ? this.getRow(event.detail[0].delta).position : null;
 

--- a/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/CollectionRow.vue
+++ b/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/CollectionRow.vue
@@ -1,12 +1,12 @@
 <template>
     <div>
-        <div class="collection-add-button-wrapper">
-            <button  class="uk-button uk-button-default" v-on:click.prevent="addRowBefore" v-html="feather.icons['plus'].toSvg({ width: 20, height: 20 })"></button>
+        <div v-if="!readOnly" class="collection-add-button-wrapper">
+            <button class="uk-button uk-button-default" v-on:click.prevent="addRowBefore" v-html="feather.icons['plus'].toSvg({ width: 20, height: 20 })"></button>
         </div>
         <div class="uk-placeholder uk-padding-small">
-            <div class="uk-sortable-handle" v-html="feather.icons['menu'].toSvg({ width: 16, height: 16 })"></div>
+            <div v-if="!readOnly" class="uk-sortable-handle" v-html="feather.icons['menu'].toSvg({ width: 16, height: 16 })"></div>
             <div :class="formLayout" v-if="prototype" v-html="prototype"></div>
-            <button class="close-button" v-html="feather.icons['x'].toSvg({ width: 20, height: 20 })" v-on:click.prevent="removeRow"></button>
+            <button v-if="!readOnly" class="close-button" v-html="feather.icons['x'].toSvg({ width: 20, height: 20 })" v-on:click.prevent="removeRow"></button>
         </div>
     </div>
 </template>
@@ -27,7 +27,8 @@
             'delta',
             'prototype',
             'formLayout',
-            'labelHidden'
+            'labelHidden',
+            'readOnly'
         ],
         methods: {
             removeRow() {

--- a/src/Bundle/CoreBundle/Field/FieldType.php
+++ b/src/Bundle/CoreBundle/Field/FieldType.php
@@ -27,7 +27,7 @@ abstract class FieldType implements FieldTypeInterface
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default'];
+    const SETTINGS = ['not_empty', 'description', 'read_only', 'default'];
 
     /**
      * All required settings for this field type.
@@ -60,6 +60,7 @@ abstract class FieldType implements FieldTypeInterface
             'required' => false,
             'not_empty' => (isset($field->getSettings()->not_empty)) ? (boolean) $field->getSettings()->not_empty : false,
             'description' => (isset($field->getSettings()->description)) ? (string) $field->getSettings()->description : '',
+            'read_only' => (isset($field->getSettings()->read_only)) ? (boolean) $field->getSettings()->read_only: false,
         ];
     }
 
@@ -148,6 +149,13 @@ abstract class FieldType implements FieldTypeInterface
         if (!empty($settingsArray['not_empty'])) {
             $context->getViolations()->addAll(
                 $context->getValidator()->validate($settingsArray['not_empty'], new Assert\Type(['type' => 'boolean', 'message' => 'noboolean_value']))
+            );
+        }
+
+        // validate read only is boolean
+        if (!empty($settingsArray['read_only'])) {
+            $context->getViolations()->addAll(
+                $context->getValidator()->validate($settingsArray['read_only'], new Assert\Type(['type' => 'boolean', 'message' => 'noboolean_value']))
             );
         }
 

--- a/src/Bundle/CoreBundle/Field/Types/LinkFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/LinkFieldType.php
@@ -81,6 +81,10 @@ class LinkFieldType extends FieldType
         if (!empty($settings->target_widget) && !is_bool($settings->target_widget)) {
             $context->buildViolation('noboolean_value')->atPath('target_widget')->addViolation();
         }
+
+        if (!empty($settings->read_only) && !is_bool($settings->read_only)) {
+            $context->buildViolation('noboolean_value')->atPath('target_widget')->addViolation();
+        }
     }
 
     /**

--- a/src/Bundle/CoreBundle/Field/Types/RangeFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/RangeFieldType.php
@@ -17,7 +17,7 @@ class RangeFieldType extends FieldType
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default', 'min', 'max', 'step'];
+    const SETTINGS = ['not_empty', 'description', 'default', 'min', 'max', 'step', 'read_only'];
 
     function getFormOptions(FieldableField $field): array
     {
@@ -28,6 +28,7 @@ class RangeFieldType extends FieldType
                     'min' => $field->getSettings()->min ?? 0,
                     'max' => $field->getSettings()->max ?? 100,
                     'step' => $field->getSettings()->step ?? 1,
+                    'read_only' => $field->getSettings()->read_only ?? false,
                 ],
             ]
         );

--- a/src/Bundle/CoreBundle/Field/Types/SortIndexFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/SortIndexFieldType.php
@@ -15,7 +15,7 @@ class SortIndexFieldType extends FieldType
 {
     const TYPE = "sortindex";
     const FORM_TYPE = IntegerType::class;
-    const SETTINGS = ['description'];
+    const SETTINGS = ['description', 'read_only'];
 
     function getGraphQLType(FieldableField $field, SchemaTypeManager $schemaTypeManager, $nestingLevel = 0)
     {

--- a/src/Bundle/CoreBundle/Field/Types/TextAreaFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/TextAreaFieldType.php
@@ -18,7 +18,7 @@ class TextAreaFieldType extends FieldType
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default', 'rows'];
+    const SETTINGS = ['not_empty', 'description', 'default', 'rows', 'read_only'];
 
     function getFormOptions(FieldableField $field): array
     {
@@ -26,7 +26,8 @@ class TextAreaFieldType extends FieldType
             parent::getFormOptions($field),
               [
                 'attr' => [
-                    'rows' => $field->getSettings()->rows ?? 2
+                    'rows' => $field->getSettings()->rows ?? 2,
+                    'read_only' => $field->getSettings()->read_only ?? false
                 ],
               ]
         );

--- a/src/Bundle/CoreBundle/Form/AutoTextType.php
+++ b/src/Bundle/CoreBundle/Form/AutoTextType.php
@@ -52,7 +52,7 @@ class AutoTextType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('text', $this->normalizeWidgetType($options['text_widget']), ['label' => $options['label'], 'not_empty' => $options['not_empty']])
+            ->add('text', $this->normalizeWidgetType($options['text_widget']), ['label' => $options['label'], 'not_empty' => $options['not_empty'], 'read_only' => $options['read_only']])
             ->add('auto', CheckboxType::class, ['label' => $options['label']]);
     }
 

--- a/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
+++ b/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
@@ -64,6 +64,10 @@ class UniteCMSCoreTypeExtension extends AbstractTypeExtension
             $view->vars['description'] = $options['description'];
         }
 
+        // pass read_only to template
+        if (isset($options['read_only'])) {
+            $view->vars['read_only'] = $options['read_only'];
+        }
     }
 
     /**
@@ -74,6 +78,7 @@ class UniteCMSCoreTypeExtension extends AbstractTypeExtension
         $resolver->setDefined('description');
         $resolver->setDefined('default');
         $resolver->setDefined('not_empty');
+        $resolver->setDefined('read_only');
 
         // If not_empty is set, also set the required option to true
         $resolver->setNormalizer('required', function(Options $options, $value){

--- a/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
+++ b/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
@@ -68,16 +68,25 @@
 
 {%- block form_widget_simple -%}
     {%- set attr = attr|merge({class: (attr.class|default('') ~ ' uk-input')|trim}) -%}
+    {% if form.vars.read_only is defined and form.vars.read_only == true %}
+        {% set attr = attr|merge({disabled: "true"}) %}
+    {% endif %}
     {{- parent() -}}
 {%- endblock form_widget_simple -%}
 
 {% block button_widget -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-button')|trim}) %}
+    {% if form.vars.read_only is defined and form.vars.read_only == true %}
+        {% set attr = attr|merge({disabled: "true"}) %}
+    {% endif %}
     {{- parent() -}}
 {%- endblock %}
 
 {%- block textarea_widget -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-textarea')|trim}) %}
+    {% if form.vars.read_only is defined and form.vars.read_only == true %}
+        {% set attr = attr|merge({disabled: "true"}) %}
+    {% endif %}
     {{- parent() -}}
 {%- endblock textarea_widget -%}
 
@@ -92,11 +101,17 @@
 
 {%- block radio_widget -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-radio')|trim}) %}
+    {% if form.vars.read_only is defined and form.vars.read_only == true %}
+        {% set attr = attr|merge({disabled: "true"}) %}
+    {% endif %}
     {{- parent() -}}
 {%- endblock radio_widget -%}
 
 {%- block choice_widget_collapsed -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-select')|trim}) %}
+    {% if form.vars.read_only is defined and form.vars.read_only == true %}
+        {% set attr = attr|merge({disabled: "true"}) %}
+    {% endif %}
     {{- parent() -}}
 {%- endblock choice_widget_collapsed -%}
 
@@ -111,6 +126,9 @@
 
 {%- block range_widget -%}
     {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-range')|trim}) %}
+    {% if form.vars.read_only is defined and form.vars.read_only == true %}
+        {% set attr = attr|merge({disabled: "true"}) %}
+    {% endif %}
     {{- parent() -}}
 {%- endblock range_widget %}
 


### PR DESCRIPTION
If present and set to true, the field will be rendered on forms but
with a 'disabled' attribute set. It will also be greyed out. This is
intended for use with fields that should be visible to users, but not
updated. An example would be fields storing IDs that link entities to
external systems. It would be useful for users to be able to see these,
but not update them as this could cause inconsistencies.

Once field-level permissions have been added, this feature may become
redundant. Fields that the user has permission to view but not edit
could automatically be disabled and greyed out.

An example field definition:
```
{
  "title": "External ID",
  "identifier": "external_id",
  "type": "text",
  "settings": {
    "read_only": true
  }
}
```