### PR TITLE
resolves #407 - Add `hidden` field setting

### DIFF
--- a/src/Bundle/CoreBundle/Field/FieldType.php
+++ b/src/Bundle/CoreBundle/Field/FieldType.php
@@ -27,7 +27,7 @@ abstract class FieldType implements FieldTypeInterface
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default'];
+    const SETTINGS = ['not_empty', 'description', 'hidden', 'default'];
 
     /**
      * All required settings for this field type.
@@ -60,6 +60,7 @@ abstract class FieldType implements FieldTypeInterface
             'required' => false,
             'not_empty' => (isset($field->getSettings()->not_empty)) ? (boolean) $field->getSettings()->not_empty : false,
             'description' => (isset($field->getSettings()->description)) ? (string) $field->getSettings()->description : '',
+            'hidden' => (isset($field->getSettings()->hidden)) ? (boolean) $field->getSettings()->hidden: false,
         ];
     }
 
@@ -148,6 +149,13 @@ abstract class FieldType implements FieldTypeInterface
         if (!empty($settingsArray['not_empty'])) {
             $context->getViolations()->addAll(
                 $context->getValidator()->validate($settingsArray['not_empty'], new Assert\Type(['type' => 'boolean', 'message' => 'noboolean_value']))
+            );
+        }
+
+        // validate hidden is boolean
+        if (!empty($settingsArray['hidden'])) {
+            $context->getViolations()->addAll(
+                $context->getValidator()->validate($settingsArray['hidden'], new Assert\Type(['type' => 'boolean', 'message' => 'noboolean_value']))
             );
         }
 

--- a/src/Bundle/CoreBundle/Field/Types/RangeFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/RangeFieldType.php
@@ -17,7 +17,7 @@ class RangeFieldType extends FieldType
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default', 'min', 'max', 'step'];
+    const SETTINGS = ['not_empty', 'description', 'default', 'min', 'max', 'step', 'hidden'];
 
     function getFormOptions(FieldableField $field): array
     {
@@ -28,6 +28,7 @@ class RangeFieldType extends FieldType
                     'min' => $field->getSettings()->min ?? 0,
                     'max' => $field->getSettings()->max ?? 100,
                     'step' => $field->getSettings()->step ?? 1,
+                    'hidden' => $field->getSettings()->hidden ?? false,
                 ],
             ]
         );

--- a/src/Bundle/CoreBundle/Field/Types/SortIndexFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/SortIndexFieldType.php
@@ -15,7 +15,7 @@ class SortIndexFieldType extends FieldType
 {
     const TYPE = "sortindex";
     const FORM_TYPE = IntegerType::class;
-    const SETTINGS = ['description'];
+    const SETTINGS = ['description', 'hidden'];
 
     function getGraphQLType(FieldableField $field, SchemaTypeManager $schemaTypeManager, $nestingLevel = 0)
     {

--- a/src/Bundle/CoreBundle/Field/Types/TextAreaFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/TextAreaFieldType.php
@@ -18,7 +18,7 @@ class TextAreaFieldType extends FieldType
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default', 'rows'];
+    const SETTINGS = ['not_empty', 'description', 'default', 'rows', 'hidden'];
 
     function getFormOptions(FieldableField $field): array
     {
@@ -26,7 +26,8 @@ class TextAreaFieldType extends FieldType
             parent::getFormOptions($field),
               [
                 'attr' => [
-                    'rows' => $field->getSettings()->rows ?? 2
+                    'rows' => $field->getSettings()->rows ?? 2,
+                    'hidden' => $field->getSettings()->hidden ?? false
                 ],
               ]
         );

--- a/src/Bundle/CoreBundle/Form/AutoTextType.php
+++ b/src/Bundle/CoreBundle/Form/AutoTextType.php
@@ -52,7 +52,7 @@ class AutoTextType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('text', $this->normalizeWidgetType($options['text_widget']), ['label' => $options['label'], 'not_empty' => $options['not_empty']])
+            ->add('text', $this->normalizeWidgetType($options['text_widget']), ['label' => $options['label'], 'not_empty' => $options['not_empty'], 'hidden' => $options['hidden']])
             ->add('auto', CheckboxType::class, ['label' => $options['label']]);
     }
 

--- a/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
+++ b/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
@@ -64,6 +64,10 @@ class UniteCMSCoreTypeExtension extends AbstractTypeExtension
             $view->vars['description'] = $options['description'];
         }
 
+        // pass hidden to template
+        if (isset($options['hidden'])) {
+            $view->vars['hidden'] = $options['hidden'];
+        }
     }
 
     /**
@@ -74,6 +78,7 @@ class UniteCMSCoreTypeExtension extends AbstractTypeExtension
         $resolver->setDefined('description');
         $resolver->setDefined('default');
         $resolver->setDefined('not_empty');
+        $resolver->setDefined('hidden');
 
         // If not_empty is set, also set the required option to true
         $resolver->setNormalizer('required', function(Options $options, $value){

--- a/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
+++ b/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
@@ -51,8 +51,10 @@
 {%- endblock button_row -%}
 
 {% block form_label -%}
-    {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' uk-form-label')|trim}) -%}
-    {{- parent() -}}
+    {% if form.vars.hidden is not defined or form.vars.hidden == false %}
+        {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' uk-form-label')|trim}) -%}
+        {{- parent() -}}
+    {%- endif -%}
 {%- endblock form_label %}
 
 {%- block form_errors -%}
@@ -67,8 +69,10 @@
 {%- endblock form_errors -%}
 
 {%- block form_widget_simple -%}
-    {%- set attr = attr|merge({class: (attr.class|default('') ~ ' uk-input')|trim}) -%}
-    {{- parent() -}}
+    {% if form.vars.hidden is not defined or form.vars.hidden == false %}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' uk-input')|trim}) -%}
+        {{- parent() -}}
+    {% endif %}
 {%- endblock form_widget_simple -%}
 
 {% block button_widget -%}
@@ -77,8 +81,10 @@
 {%- endblock %}
 
 {%- block textarea_widget -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-textarea')|trim}) %}
-    {{- parent() -}}
+    {% if form.vars.hidden is not defined or form.vars.hidden == false %}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-textarea')|trim}) %}
+        {{- parent() -}}
+    {% endif %}
 {%- endblock textarea_widget -%}
 
 {%- block checkbox_widget -%}
@@ -110,8 +116,10 @@
 {%- endblock choice_widget_expanded -%}
 
 {%- block range_widget -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-range')|trim}) %}
-    {{- parent() -}}
+    {% if form.vars.hidden is not defined or form.vars.hidden == false %}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' uk-range')|trim}) %}
+        {{- parent() -}}
+    {% endif %}
 {%- endblock range_widget %}
 
 {%- block submit_widget -%}


### PR DESCRIPTION
If present and set to true, the field will not be rendered on forms.
The field will remain editable by the user, it just won't be displayed.
One use case is for a sort index field linked to a drag-and-drop list
interface. Dragging list items to change their order will update the
linked field, but we don't want the actual position field visible to
users.

An example field definition:
```
{
  "title": "Position",
  "identifier": "position",
  "type": "sortindex",
  "settings": {
    "hidden": true
  }
}
```