### PR TITLE
Add `max_displayed_rows` setting for table collection fields

### DIFF
--- a/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/views/Fields/Collection.vue
+++ b/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/views/Fields/Collection.vue
@@ -1,6 +1,6 @@
 <template>
     <div :style="style" class="view-field view-field-collection">
-        <div class="view-field-collection-row" v-for="(c_row,index) in value">
+        <div class="view-field-collection-row" v-for="(c_row,index) in value" :key="index" v-if="limitCollectionRows(index, settings)">
             <component v-for="(v,identifier) in settings.fields"
                        :key="identifier + index"
                        :is="$uniteCMSViewFields.resolve(v.type)"
@@ -34,6 +34,9 @@
             },
         },
         computed: {
+            limitCollectionRows() {
+                return (i, s) => ("max_display_rows" in s) ? i < s.max_display_rows : true;
+            },
         },
     }
 </script>


### PR DESCRIPTION
If present, at most this number of collection items will be displayed
in each table row.

One use case for this is only displaying the first product image in a
product list view. Products can have more than one image, but you
wouldn't normally want to show all images for each product in a table
row. With this setting, we can only show the first image.

An example field definition:
```
{
    "title": "View with Image thumbnail",
    "identifier": "with_thumbnail",
    "type": "table",
    "settings": {
        "sort": {
            "field": "created",
            "asc": false,
            "sortable": false
        },
        "fields": {
            "name": {
                "label": "Name"
            },
            "images": {
                "label": "Image Previews",
                "type": "collection",
                "settings": {
                    "fields": {
                        "url": {
                            "label": "Preview"
                        }
                    },
                    "max_displayed_rows": 1
                }
            }
        }
    }
}
```