### PR TITLE
Fix filename in StorageBundle webpack config

### DIFF
--- a/src/Bundle/StorageBundle/Resources/webpack/main.js
+++ b/src/Bundle/StorageBundle/Resources/webpack/main.js
@@ -2,7 +2,7 @@
 import Vue from "vue";
 import vueCustomElement from 'vue-custom-element';
 
-import File from "./vue/field/file.vue";
+import File from "./vue/field/File.vue";
 import uniteViewFieldsPlugin from "../../../CoreBundle/Resources/webpack/js/uniteViewFieldsPlugin";
 
 // Use VueCustomElement


### PR DESCRIPTION
Trying to compile using webpack in StorageBundle fails due to an
import statement with an incorrect path: `./vue/field/file.vue`.
Changing this to `./vue/field/File.vue` resolves the issue.