### PR TITLE
Add rows_per_page setting to table and tree views

### DIFF
--- a/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
+++ b/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
@@ -410,7 +410,7 @@ class CollectionFieldType extends FieldType implements NestableFieldTypeInterfac
             // normalize settings for nested fields.
             if(!empty($settings['settings']['fields'])) {
                 $processor = new Processor();
-                $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create(self::getNestableFieldable($field), $fieldTypeManager), ['settings' => ['fields' => $settings['settings']['fields']]]);
+                $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create(self::getNestableFieldable($field)), ['settings' => ['fields' => $settings['settings']['fields']]]);
                 $settings['settings']['fields'] = $config['fields'];
 
                 // Template will only include assets from root fields, so we need to add any child templates to the root field.

--- a/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
+++ b/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
@@ -19,7 +19,7 @@ use UniteCMS\CoreBundle\Field\NestableFieldTypeInterface;
 use UniteCMS\CoreBundle\Form\FieldableFormField;
 use UniteCMS\CoreBundle\Form\FieldableFormType;
 use UniteCMS\CoreBundle\SchemaType\SchemaTypeManager;
-use UniteCMS\CoreBundle\View\Types\TableViewConfiguration;
+use UniteCMS\CoreBundle\View\Types\Factories\ViewConfigurationFactoryInterface;
 
 class CollectionFieldType extends FieldType implements NestableFieldTypeInterface
 {
@@ -30,11 +30,13 @@ class CollectionFieldType extends FieldType implements NestableFieldTypeInterfac
 
     private $collectionFieldTypeFactory;
     private $fieldTypeManager;
+    private $tableViewConfigurationFactory;
 
-    function __construct(CollectionFieldTypeFactory $collectionFieldTypeFactory, FieldTypeManager $fieldTypeManager)
+    function __construct(CollectionFieldTypeFactory $collectionFieldTypeFactory, FieldTypeManager $fieldTypeManager, ViewConfigurationFactoryInterface $tableViewConfigurationFactory)
     {
         $this->collectionFieldTypeFactory = $collectionFieldTypeFactory;
         $this->fieldTypeManager = $fieldTypeManager;
+        $this->tableViewConfigurationFactory = $tableViewConfigurationFactory;
     }
 
     /**
@@ -408,7 +410,7 @@ class CollectionFieldType extends FieldType implements NestableFieldTypeInterfac
             // normalize settings for nested fields.
             if(!empty($settings['settings']['fields'])) {
                 $processor = new Processor();
-                $config = $processor->processConfiguration(new TableViewConfiguration(self::getNestableFieldable($field), $fieldTypeManager), ['settings' => ['fields' => $settings['settings']['fields']]]);
+                $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create(self::getNestableFieldable($field), $fieldTypeManager), ['settings' => ['fields' => $settings['settings']['fields']]]);
                 $settings['settings']['fields'] = $config['fields'];
 
                 // Template will only include assets from root fields, so we need to add any child templates to the root field.

--- a/src/Bundle/CollectionFieldBundle/Resources/config/services.yml
+++ b/src/Bundle/CollectionFieldBundle/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
   # A collection input field that allows to add multiple, repeatable sub fields
   UniteCMS\CollectionFieldBundle\Field\Types\CollectionFieldType:
     tags: [unite_cms.field_type]
-    arguments: ['@unite.cms.collection_field.collection_field_type_factory', '@unite.cms.field_type_manager' ]
+    arguments: ['@unite.cms.collection_field.collection_field_type_factory', '@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.table_view']
 
 
   unite.cms.collection_field.collection_field_type_factory:

--- a/src/Bundle/CollectionFieldBundle/Tests/NestedCollectionFieldEventHooksTest.php
+++ b/src/Bundle/CollectionFieldBundle/Tests/NestedCollectionFieldEventHooksTest.php
@@ -16,6 +16,7 @@ use UniteCMS\CoreBundle\Entity\SettingTypeField;
 use UniteCMS\CoreBundle\Field\FieldType;
 use UniteCMS\CoreBundle\Field\FieldTypeInterface;
 use UniteCMS\CoreBundle\Field\FieldTypeManager;
+use UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory;
 
 class NestedCollectionFieldEventHooksTest extends TestCase {
 
@@ -69,7 +70,8 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         $this->repository = $this->createMock(EntityRepository::class);
         $this->collectionFieldType = new CollectionFieldType(
             $this->createMock(CollectionFieldTypeFactory::class),
-            $fieldTypeManager
+            $fieldTypeManager,
+            new TableViewConfigurationFactory(100)
         );
 
         $this->contentTypeField = new ContentTypeField();

--- a/src/Bundle/CollectionFieldBundle/Tests/NestedCollectionFieldEventHooksTest.php
+++ b/src/Bundle/CollectionFieldBundle/Tests/NestedCollectionFieldEventHooksTest.php
@@ -71,7 +71,7 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         $this->collectionFieldType = new CollectionFieldType(
             $this->createMock(CollectionFieldTypeFactory::class),
             $fieldTypeManager,
-            new TableViewConfigurationFactory(100)
+            new TableViewConfigurationFactory($fieldTypeManager, 100)
         );
 
         $this->contentTypeField = new ContentTypeField();

--- a/src/Bundle/CollectionFieldBundle/Tests/NestedFieldAlterTest.php
+++ b/src/Bundle/CollectionFieldBundle/Tests/NestedFieldAlterTest.php
@@ -19,6 +19,7 @@ use UniteCMS\CoreBundle\Entity\FieldableField;
 use UniteCMS\CoreBundle\Field\FieldableFieldSettings;
 use UniteCMS\CoreBundle\Field\FieldType;
 use UniteCMS\CoreBundle\Field\FieldTypeManager;
+use UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory;
 
 class NestedFieldAlterTest extends TestCase
 {
@@ -26,7 +27,13 @@ class NestedFieldAlterTest extends TestCase
 
         $manager = new FieldTypeManager();
 
-        $manager->registerFieldType(new CollectionFieldType($this->createMock(CollectionFieldTypeFactory::class), $manager));
+        $manager->registerFieldType(
+            new CollectionFieldType(
+                $this->createMock(CollectionFieldTypeFactory::class),
+                $manager,
+                new TableViewConfigurationFactory(100)
+            )
+        );
         $manager->registerFieldType(new class extends FieldType {
             const TYPE = 't_f1';
             public function alterData(FieldableField $field, &$data, FieldableContent $content, $rootData) { $data[$field->getIdentifier()] = 'FOO'; }

--- a/src/Bundle/CollectionFieldBundle/Tests/NestedFieldAlterTest.php
+++ b/src/Bundle/CollectionFieldBundle/Tests/NestedFieldAlterTest.php
@@ -31,7 +31,7 @@ class NestedFieldAlterTest extends TestCase
             new CollectionFieldType(
                 $this->createMock(CollectionFieldTypeFactory::class),
                 $manager,
-                new TableViewConfigurationFactory(100)
+                new TableViewConfigurationFactory($manager, 100)
             )
         );
         $manager->registerFieldType(new class extends FieldType {

--- a/src/Bundle/CoreBundle/DependencyInjection/UniteCMSCoreExtension.php
+++ b/src/Bundle/CoreBundle/DependencyInjection/UniteCMSCoreExtension.php
@@ -35,8 +35,12 @@ class UniteCMSCoreExtension extends Extension
         $container->getDefinition('unite.cms.graphql.schema_type_manager')->setArgument(0, $config['maximum_nesting_level']);
         $container->getDefinition('UniteCMS\CoreBundle\SchemaType\Types\MaximumNestingLevelType')->setArgument(0, $config['maximum_nesting_level']);
 
-        // Set maximum query limit as fifth argument to query type and maximum reference of field type.
+        // Set maximum query limit as sixth argument to query type and maximum reference of field type, and
+        // as first argument to table/tree/grid view config factory classes.
         $container->getDefinition('UniteCMS\CoreBundle\SchemaType\Types\QueryType')->setArgument(5, $config['maximum_query_limit']);
         $container->getDefinition('UniteCMS\CoreBundle\Field\Types\ReferenceOfFieldType')->setArgument(5, $config['maximum_query_limit']);
+        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\GridViewConfigurationFactory')->setArgument(0, $config['maximum_query_limit']);
+        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory')->setArgument(0, $config['maximum_query_limit']);
+        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\TreeViewConfigurationFactory')->setArgument(0, $config['maximum_query_limit']);
     }
 }

--- a/src/Bundle/CoreBundle/DependencyInjection/UniteCMSCoreExtension.php
+++ b/src/Bundle/CoreBundle/DependencyInjection/UniteCMSCoreExtension.php
@@ -36,11 +36,11 @@ class UniteCMSCoreExtension extends Extension
         $container->getDefinition('UniteCMS\CoreBundle\SchemaType\Types\MaximumNestingLevelType')->setArgument(0, $config['maximum_nesting_level']);
 
         // Set maximum query limit as sixth argument to query type and maximum reference of field type, and
-        // as first argument to table/tree/grid view config factory classes.
+        // as second argument to table/tree/grid view config factory classes.
         $container->getDefinition('UniteCMS\CoreBundle\SchemaType\Types\QueryType')->setArgument(5, $config['maximum_query_limit']);
         $container->getDefinition('UniteCMS\CoreBundle\Field\Types\ReferenceOfFieldType')->setArgument(5, $config['maximum_query_limit']);
-        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\GridViewConfigurationFactory')->setArgument(0, $config['maximum_query_limit']);
-        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory')->setArgument(0, $config['maximum_query_limit']);
-        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\TreeViewConfigurationFactory')->setArgument(0, $config['maximum_query_limit']);
+        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\GridViewConfigurationFactory')->setArgument(1, $config['maximum_query_limit']);
+        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory')->setArgument(1, $config['maximum_query_limit']);
+        $container->getDefinition('UniteCMS\CoreBundle\View\Types\Factories\TreeViewConfigurationFactory')->setArgument(1, $config['maximum_query_limit']);
     }
 }

--- a/src/Bundle/CoreBundle/Field/Types/ReferenceFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/ReferenceFieldType.php
@@ -25,7 +25,7 @@ use UniteCMS\CoreBundle\Field\FieldTypeManager;
 use UniteCMS\CoreBundle\Form\ReferenceType;
 use UniteCMS\CoreBundle\SchemaType\IdentifierNormalizer;
 use UniteCMS\CoreBundle\Service\ReferenceResolver;
-use UniteCMS\CoreBundle\View\Types\TableViewConfiguration;
+use UniteCMS\CoreBundle\View\Types\Factories\ViewConfigurationFactoryInterface;
 use UniteCMS\CoreBundle\View\ViewTypeInterface;
 use UniteCMS\CoreBundle\View\ViewTypeManager;
 use UniteCMS\CoreBundle\Entity\View;
@@ -58,6 +58,7 @@ class ReferenceFieldType extends FieldType
     private $templating;
     private $csrfTokenManager;
     private $router;
+    private $tableViewConfigurationFactory;
 
     function __construct(
         ValidatorInterface $validator,
@@ -67,7 +68,8 @@ class ReferenceFieldType extends FieldType
         ViewTypeManager $viewTypeManager,
         TwigEngine $templating,
         Router $router,
-        CsrfTokenManager $csrfTokenManager
+        CsrfTokenManager $csrfTokenManager,
+        ViewConfigurationFactoryInterface $tableViewConfigurationFactory
     ) {
         $this->referenceResolver = new ReferenceResolver($uniteCMSManager, $entityManager, $authorizationChecker);
         $this->validator = $validator;
@@ -77,6 +79,7 @@ class ReferenceFieldType extends FieldType
         $this->templating = $templating;
         $this->router = $router;
         $this->csrfTokenManager = $csrfTokenManager;
+        $this->tableViewConfigurationFactory = $tableViewConfigurationFactory;
     }
 
     /**
@@ -332,7 +335,7 @@ class ReferenceFieldType extends FieldType
                 $this->referenceResolver->resolveDomain($field->getSettings()->domain),
                 $field->getSettings()->content_type);
             $processor = new Processor();
-            $config = $processor->processConfiguration(new TableViewConfiguration($contentType, $fieldTypeManager), ['settings' => ['fields' => $settings['settings']['fields']]]);
+            $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create($contentType, $fieldTypeManager), ['settings' => ['fields' => $settings['settings']['fields']]]);
             $settings['settings']['fields'] = $config['fields'];
 
             // Template will only include assets from root fields, so we need to add any child templates to the root field.

--- a/src/Bundle/CoreBundle/Field/Types/ReferenceFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/ReferenceFieldType.php
@@ -335,7 +335,7 @@ class ReferenceFieldType extends FieldType
                 $this->referenceResolver->resolveDomain($field->getSettings()->domain),
                 $field->getSettings()->content_type);
             $processor = new Processor();
-            $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create($contentType, $fieldTypeManager), ['settings' => ['fields' => $settings['settings']['fields']]]);
+            $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create($contentType), ['settings' => ['fields' => $settings['settings']['fields']]]);
             $settings['settings']['fields'] = $config['fields'];
 
             // Template will only include assets from root fields, so we need to add any child templates to the root field.

--- a/src/Bundle/CoreBundle/Resources/config/services.fieldTypes.yml
+++ b/src/Bundle/CoreBundle/Resources/config/services.fieldTypes.yml
@@ -36,7 +36,7 @@ services:
   UniteCMS\CoreBundle\Field\Types\ReferenceFieldType:
     public: false
     tags: [unite_cms.field_type]
-    arguments: ['@validator', '@security.authorization_checker', '@unite.cms.manager', '@doctrine.orm.entity_manager', '@unite.cms.view_type_manager', '@templating.engine.twig', '@router', '@security.csrf.token_manager']
+    arguments: ['@validator', '@security.authorization_checker', '@unite.cms.manager', '@doctrine.orm.entity_manager', '@unite.cms.view_type_manager', '@templating.engine.twig', '@router', '@security.csrf.token_manager', '@unite.cms.field_type.config_factory.table_view']
 
   # A reference input field that allows to add a reference to a content item in any domain in the same organization.
   UniteCMS\CoreBundle\Field\Types\ReferenceOfFieldType:

--- a/src/Bundle/CoreBundle/Resources/config/services.viewTypes.yml
+++ b/src/Bundle/CoreBundle/Resources/config/services.viewTypes.yml
@@ -6,21 +6,21 @@ services:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.table_view']
+      ['@unite.cms.field_type.config_factory.table_view']
 
   # A grid view type that renders all content documents in a 2d grid.
   UniteCMS\CoreBundle\View\Types\GridViewType:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.grid_view']
+      ['@unite.cms.field_type.config_factory.grid_view']
 
   # A tree view type that renders content as a nested tree.
   UniteCMS\CoreBundle\View\Types\TreeViewType:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.tree_view']
+      ['@unite.cms.field_type.config_factory.tree_view']
 
   # @deprecated
   # A table view type that allows the user to sort rows via drag and drop.
@@ -28,25 +28,25 @@ services:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.table_view']
+      ['@unite.cms.field_type.config_factory.table_view']
 
   # Grid view configuration object factory
   UniteCMS\CoreBundle\View\Types\Factories\GridViewConfigurationFactory:
     public: false
     tags: [unite_cms.field_type.config_factory]
-    arguments: [100]
+    arguments: ['@unite.cms.field_type_manager', 100]
 
   # Table view configuration object factory
   UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory:
     public: false
     tags: [unite_cms.field_type.config_factory]
-    arguments: [100]
+    arguments: ['@unite.cms.field_type_manager', 100]
 
   # Tree view configuration object factory
   UniteCMS\CoreBundle\View\Types\Factories\TreeViewConfigurationFactory:
     public: false
     tags: [unite_cms.field_type.config_factory]
-    arguments: [100]
+    arguments: ['@unite.cms.field_type_manager', 100]
 
   unite.cms.field_type.config_factory.grid_view:
     alias: UniteCMS\CoreBundle\View\Types\Factories\GridViewConfigurationFactory

--- a/src/Bundle/CoreBundle/Resources/config/services.viewTypes.yml
+++ b/src/Bundle/CoreBundle/Resources/config/services.viewTypes.yml
@@ -6,21 +6,21 @@ services:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager']
+      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.table_view']
 
   # A grid view type that renders all content documents in a 2d grid.
   UniteCMS\CoreBundle\View\Types\GridViewType:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager']
+      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.grid_view']
 
   # A tree view type that renders content as a nested tree.
   UniteCMS\CoreBundle\View\Types\TreeViewType:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager']
+      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.tree_view']
 
   # @deprecated
   # A table view type that allows the user to sort rows via drag and drop.
@@ -28,4 +28,34 @@ services:
     tags: [unite_cms.view_type]
     public: false
     arguments:
-      ['@unite.cms.field_type_manager']
+      ['@unite.cms.field_type_manager', '@unite.cms.field_type.config_factory.table_view']
+
+  # Grid view configuration object factory
+  UniteCMS\CoreBundle\View\Types\Factories\GridViewConfigurationFactory:
+    public: false
+    tags: [unite_cms.field_type.config_factory]
+    arguments: [100]
+
+  # Table view configuration object factory
+  UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory:
+    public: false
+    tags: [unite_cms.field_type.config_factory]
+    arguments: [100]
+
+  # Tree view configuration object factory
+  UniteCMS\CoreBundle\View\Types\Factories\TreeViewConfigurationFactory:
+    public: false
+    tags: [unite_cms.field_type.config_factory]
+    arguments: [100]
+
+  unite.cms.field_type.config_factory.grid_view:
+    alias: UniteCMS\CoreBundle\View\Types\Factories\GridViewConfigurationFactory
+    public: true
+
+  unite.cms.field_type.config_factory.table_view:
+    alias: UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory
+    public: true
+
+  unite.cms.field_type.config_factory.tree_view:
+    alias: UniteCMS\CoreBundle\View\Types\Factories\TreeViewConfigurationFactory
+    public: true

--- a/src/Bundle/CoreBundle/Resources/webpack/js/uniteViewDataFechter.js
+++ b/src/Bundle/CoreBundle/Resources/webpack/js/uniteViewDataFechter.js
@@ -51,6 +51,10 @@ export default {
             fetcher.filter(bag.settings.filter);
         }
 
+        if(bag.settings.rows_per_page) {
+            fetcher.limit = bag.settings.rows_per_page;
+        }
+
         fetcher.client = new GraphQLClient(bag.endpoint, clientConfig);
 
         let contentTypeName = bag.settings.contentType.charAt(0).toUpperCase() + bag.settings.contentType.slice(1);

--- a/src/Bundle/CoreBundle/Resources/webpack/vue/views/Base/BaseView.vue
+++ b/src/Bundle/CoreBundle/Resources/webpack/vue/views/Base/BaseView.vue
@@ -58,6 +58,7 @@
             let bag = JSON.parse(this.parameters);
             let fields = bag.settings.fields;
             let error = null;
+            let limit = bag.settings.rows_per_page ? bag.settings.rows_per_page : 10;
             let fieldQuery = [];
             let filterQuery = [];
             let actions = bag.settings.actions;
@@ -105,7 +106,7 @@
                 sort: sort,
                 actions: actions,
                 initialSort: Object.assign({}, sort),
-                limit: 10,
+                limit: limit,
                 page: 1,
                 total: 0,
                 autoUpdateFields: [],

--- a/src/Bundle/CoreBundle/Tests/Form/ReferenceOfTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Form/ReferenceOfTypeTest.php
@@ -125,7 +125,7 @@ class ReferenceOfTypeTest extends TestCase
         $viewTypeManager = $this->createMock(ViewTypeManager::class);
         $fieldTypeManager = $this->createMock(FieldTypeManager::class);
         $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(
-            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory($fieldTypeManager, 100))
+            new TableViewType(new TableViewConfigurationFactory($fieldTypeManager, 100))
         );
         $viewParameterBag = new ViewParameterBag();
         $viewTypeManager->expects($this->any())->method('getTemplateRenderParameters')->willReturn($viewParameterBag);
@@ -147,7 +147,7 @@ class ReferenceOfTypeTest extends TestCase
         $viewTypeManager = $this->createMock(ViewTypeManager::class);
         $fieldTypeManager = $this->createMock(FieldTypeManager::class);
         $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(
-            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory($fieldTypeManager, 100))
+            new TableViewType(new TableViewConfigurationFactory($fieldTypeManager, 100))
         );
         $viewParameterBag = new ViewParameterBag();
         $viewTypeManager->expects($this->any())->method('getTemplateRenderParameters')->willReturn($viewParameterBag);

--- a/src/Bundle/CoreBundle/Tests/Form/ReferenceOfTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Form/ReferenceOfTypeTest.php
@@ -125,7 +125,7 @@ class ReferenceOfTypeTest extends TestCase
         $viewTypeManager = $this->createMock(ViewTypeManager::class);
         $fieldTypeManager = $this->createMock(FieldTypeManager::class);
         $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(
-            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory(100))
+            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory($fieldTypeManager, 100))
         );
         $viewParameterBag = new ViewParameterBag();
         $viewTypeManager->expects($this->any())->method('getTemplateRenderParameters')->willReturn($viewParameterBag);
@@ -147,7 +147,7 @@ class ReferenceOfTypeTest extends TestCase
         $viewTypeManager = $this->createMock(ViewTypeManager::class);
         $fieldTypeManager = $this->createMock(FieldTypeManager::class);
         $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(
-            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory(100))
+            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory($fieldTypeManager, 100))
         );
         $viewParameterBag = new ViewParameterBag();
         $viewTypeManager->expects($this->any())->method('getTemplateRenderParameters')->willReturn($viewParameterBag);

--- a/src/Bundle/CoreBundle/Tests/Form/ReferenceOfTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Form/ReferenceOfTypeTest.php
@@ -16,6 +16,7 @@ use UniteCMS\CoreBundle\Form\ReferenceOfType;
 use UniteCMS\CoreBundle\View\Types\TableViewType;
 use UniteCMS\CoreBundle\View\ViewParameterBag;
 use UniteCMS\CoreBundle\View\ViewTypeManager;
+use UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory;
 
 class ReferenceOfTypeTest extends TestCase
 {
@@ -123,7 +124,9 @@ class ReferenceOfTypeTest extends TestCase
     {
         $viewTypeManager = $this->createMock(ViewTypeManager::class);
         $fieldTypeManager = $this->createMock(FieldTypeManager::class);
-        $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(new TableViewType($fieldTypeManager));
+        $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(
+            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory(100))
+        );
         $viewParameterBag = new ViewParameterBag();
         $viewTypeManager->expects($this->any())->method('getTemplateRenderParameters')->willReturn($viewParameterBag);
         $dispatcherMock = $this->createMock(EventDispatcherInterface::class);
@@ -143,7 +146,9 @@ class ReferenceOfTypeTest extends TestCase
     {
         $viewTypeManager = $this->createMock(ViewTypeManager::class);
         $fieldTypeManager = $this->createMock(FieldTypeManager::class);
-        $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(new TableViewType($fieldTypeManager));
+        $viewTypeManager->expects($this->any())->method('getViewType')->willReturn(
+            new TableViewType($fieldTypeManager, new TableViewConfigurationFactory(100))
+        );
         $viewParameterBag = new ViewParameterBag();
         $viewTypeManager->expects($this->any())->method('getTemplateRenderParameters')->willReturn($viewParameterBag);
         $dispatcherMock = $this->createMock(EventDispatcherInterface::class);

--- a/src/Bundle/CoreBundle/Tests/View/DeprecatedSortableTableViewTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/View/DeprecatedSortableTableViewTypeTest.php
@@ -107,7 +107,7 @@ class OldSortableTableViewTypeTest extends ContainerAwareTestCase
         // View should not be valid.
         $errors = static::$container->get('validator')->validate($view);
         $this->assertCount(1, $errors);
-        $this->assertEquals('Unrecognized option "foo" under "settings". Available options are "actions", "columns", "fields", "filter", "sort", "sort_asc", "sort_field".', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('Unrecognized option "foo" under "settings". Available options are "actions", "columns", "fields", "filter", "rows_per_page", "sort", "sort_asc", "sort_field".', $errors->get(0)->getMessageTemplate());
 
         // Test validating invalid columns.
         $view->setSettings(new ViewSettings(['columns' => 'string', 'sort_field' => 'position']));

--- a/src/Bundle/CoreBundle/Tests/View/DeprecatedTableViewTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/View/DeprecatedTableViewTypeTest.php
@@ -108,7 +108,7 @@ class DeprecatedTableViewTypeTest extends ContainerAwareTestCase
         // View should not be valid.
         $errors = static::$container->get('validator')->validate($view);
         $this->assertCount(1, $errors);
-        $this->assertEquals('Unrecognized option "foo" under "settings". Available options are "actions", "columns", "fields", "filter", "sort", "sort_asc", "sort_field".', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('Unrecognized option "foo" under "settings". Available options are "actions", "columns", "fields", "filter", "rows_per_page", "sort", "sort_asc", "sort_field".', $errors->get(0)->getMessageTemplate());
 
         $view->setSettings(new ViewSettings([]));
 

--- a/src/Bundle/CoreBundle/Tests/View/TableViewConfigurationTest.php
+++ b/src/Bundle/CoreBundle/Tests/View/TableViewConfigurationTest.php
@@ -197,6 +197,33 @@ class TableViewConfigurationTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Invalid type for path "settings.rows_per_page". Expected scalar, but got array.
+     */
+    public function testInvalidRowsPerPageSettingsKeyArray()
+    {
+        $this->processor->processConfiguration($this->configuration, ['settings' => ['rows_per_page' => ['foo' => 'baa']]]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Invalid rows_per_page configuration - must be an integer
+     */
+    public function testInvalidRowsPerPageSettingsKeyString()
+    {
+        $this->processor->processConfiguration($this->configuration, ['settings' => ['rows_per_page' => '20']]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Invalid rows_per_page configuration - must be an integer
+     */
+    public function testInvalidRowsPerPageSettingsKeyFloat()
+    {
+        $this->processor->processConfiguration($this->configuration, ['settings' => ['rows_per_page' => 20.5]]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Unrecognized option "foo" under "settings.sort"
      */
     public function testInvalidSortSettingsKey()

--- a/src/Bundle/CoreBundle/Tests/View/TableViewConfigurationTest.php
+++ b/src/Bundle/CoreBundle/Tests/View/TableViewConfigurationTest.php
@@ -52,7 +52,7 @@ class TableViewConfigurationTest extends TestCase
             ['textarea', new TextAreaFieldType()],
         ]));
 
-        $this->configuration = new TableViewConfiguration($this->view->getContentType(), $this->fieldTypeManager);
+        $this->configuration = new TableViewConfiguration($this->view->getContentType(), $this->fieldTypeManager, 80);
         $this->processor = new Processor();
     }
 
@@ -220,6 +220,15 @@ class TableViewConfigurationTest extends TestCase
     public function testInvalidRowsPerPageSettingsKeyFloat()
     {
         $this->processor->processConfiguration($this->configuration, ['settings' => ['rows_per_page' => 20.5]]);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedExceptionMessage Invalid rows_per_page configuration - must be within max_query_limit of 80
+     */
+    public function testInvalidRowsPerPageSettingsKeyMaxQueryLimit()
+    {
+        $this->processor->processConfiguration($this->configuration, ['settings' => ['rows_per_page' => 90]]);
     }
 
     /**

--- a/src/Bundle/CoreBundle/Tests/View/TreeViewTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/View/TreeViewTypeTest.php
@@ -218,6 +218,31 @@ class TreeViewTypeTest extends ContainerAwareTestCase
         $this->view->setSettings(new ViewSettings(['children_field' => 'child_comments']));
         $this->assertCount(0, static::$container->get('validator')->validate($this->view));
 
+
+        // A tree view with a non-scalar "rows_per_page" field is not valid
+        $this->view->setSettings(new ViewSettings(['children_field' => 'child_comments', 'rows_per_page' => ['foo' => 'baa']]));
+        $errors = static::$container->get('validator')->validate($this->view);
+        $this->assertCount(1, $errors);
+        $this->assertEquals('Invalid type for path "settings.rows_per_page". Expected scalar, but got array.', $errors->get(0)->getMessage());
+
+        // A tree view with a string "rows_per_page" field is not valid
+        $this->view->setSettings(new ViewSettings(['children_field' => 'child_comments', 'rows_per_page' => '20']));
+        $errors = static::$container->get('validator')->validate($this->view);
+        $this->assertCount(1, $errors);
+        $this->assertEquals('Invalid rows_per_page configuration - must be an integer', $errors->get(0)->getMessage());
+
+        // A tree view with a float "rows_per_page" field is not valid
+        $this->view->setSettings(new ViewSettings(['children_field' => 'child_comments', 'rows_per_page' => 20.5]));
+        $errors = static::$container->get('validator')->validate($this->view);
+        $this->assertCount(1, $errors);
+        $this->assertEquals('Invalid rows_per_page configuration - must be an integer', $errors->get(0)->getMessage());
+
+        // A tree view with an integer "rows_per_page" field is valid
+        $this->view->setSettings(new ViewSettings(['children_field' => 'child_comments', 'rows_per_page' => 20]));
+        $errors = static::$container->get('validator')->validate($this->view);
+        $this->assertCount(0, static::$container->get('validator')->validate($this->view));
+
+
         // Test templateRenderParameters.
         $parameters = static::$container->get('unite.cms.view_type_manager')->getTemplateRenderParameters($this->view);
         $this->assertTrue($parameters->isSelectModeNone());

--- a/src/Bundle/CoreBundle/View/Types/Factories/GridViewConfigurationFactory.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/GridViewConfigurationFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UniteCMS\CoreBundle\View\Types\Factories;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use UniteCMS\CoreBundle\Entity\Fieldable;
+use UniteCMS\CoreBundle\Field\FieldTypeManager;
+use UniteCMS\CoreBundle\View\Types\GridViewConfiguration;
+
+class GridViewConfigurationFactory implements ViewConfigurationFactoryInterface
+{
+    protected $maxQueryLimit;
+
+    public function __construct(int $maxQueryLimit)
+    {
+        $this->maxQueryLimit = $maxQueryLimit;
+    }
+
+    /**
+     * @param Fieldable $fieldable
+     * @param FieldTypeManager $fieldTypeManager
+     * @return GridViewConfiguration
+     */
+    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface
+    {
+        return new GridViewConfiguration($fieldable, $fieldTypeManager, $this->maxQueryLimit);
+    }
+}

--- a/src/Bundle/CoreBundle/View/Types/Factories/GridViewConfigurationFactory.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/GridViewConfigurationFactory.php
@@ -10,19 +10,20 @@ use UniteCMS\CoreBundle\View\Types\GridViewConfiguration;
 class GridViewConfigurationFactory implements ViewConfigurationFactoryInterface
 {
     protected $maxQueryLimit;
+    protected $fieldTypeManager;
 
-    public function __construct(int $maxQueryLimit)
+    public function __construct(FieldTypeManager $fieldTypeManager, int $maxQueryLimit)
     {
+        $this->fieldTypeManager = $fieldTypeManager;
         $this->maxQueryLimit = $maxQueryLimit;
     }
 
     /**
      * @param Fieldable $fieldable
-     * @param FieldTypeManager $fieldTypeManager
      * @return GridViewConfiguration
      */
-    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface
+    public function create(Fieldable $fieldable): ConfigurationInterface
     {
-        return new GridViewConfiguration($fieldable, $fieldTypeManager, $this->maxQueryLimit);
+        return new GridViewConfiguration($fieldable, $this->fieldTypeManager, $this->maxQueryLimit);
     }
 }

--- a/src/Bundle/CoreBundle/View/Types/Factories/TableViewConfigurationFactory.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/TableViewConfigurationFactory.php
@@ -10,19 +10,20 @@ use UniteCMS\CoreBundle\View\Types\TableViewConfiguration;
 class TableViewConfigurationFactory implements ViewConfigurationFactoryInterface
 {
     protected $maxQueryLimit;
+    protected $fieldTypeManager;
 
-    public function __construct(int $maxQueryLimit)
+    public function __construct(FieldTypeManager $fieldTypeManager, int $maxQueryLimit)
     {
+        $this->fieldTypeManager = $fieldTypeManager;
         $this->maxQueryLimit = $maxQueryLimit;
     }
 
     /**
      * @param Fieldable $fieldable
-     * @param FieldTypeManager $fieldTypeManager
      * @return TableViewConfiguration
      */
-    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface
+    public function create(Fieldable $fieldable): ConfigurationInterface
     {
-        return new TableViewConfiguration($fieldable, $fieldTypeManager, $this->maxQueryLimit);
+        return new TableViewConfiguration($fieldable, $this->fieldTypeManager, $this->maxQueryLimit);
     }
 }

--- a/src/Bundle/CoreBundle/View/Types/Factories/TableViewConfigurationFactory.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/TableViewConfigurationFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UniteCMS\CoreBundle\View\Types\Factories;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use UniteCMS\CoreBundle\Entity\Fieldable;
+use UniteCMS\CoreBundle\Field\FieldTypeManager;
+use UniteCMS\CoreBundle\View\Types\TableViewConfiguration;
+
+class TableViewConfigurationFactory implements ViewConfigurationFactoryInterface
+{
+    protected $maxQueryLimit;
+
+    public function __construct(int $maxQueryLimit)
+    {
+        $this->maxQueryLimit = $maxQueryLimit;
+    }
+
+    /**
+     * @param Fieldable $fieldable
+     * @param FieldTypeManager $fieldTypeManager
+     * @return TableViewConfiguration
+     */
+    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface
+    {
+        return new TableViewConfiguration($fieldable, $fieldTypeManager, $this->maxQueryLimit);
+    }
+}

--- a/src/Bundle/CoreBundle/View/Types/Factories/TreeViewConfigurationFactory.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/TreeViewConfigurationFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UniteCMS\CoreBundle\View\Types\Factories;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use UniteCMS\CoreBundle\Entity\Fieldable;
+use UniteCMS\CoreBundle\Field\FieldTypeManager;
+use UniteCMS\CoreBundle\View\Types\TreeViewConfiguration;
+
+class TreeViewConfigurationFactory implements ViewConfigurationFactoryInterface
+{
+    protected $maxQueryLimit;
+
+    public function __construct(int $maxQueryLimit)
+    {
+        $this->maxQueryLimit = $maxQueryLimit;
+    }
+
+    /**
+     * @param Fieldable $fieldable
+     * @param FieldTypeManager $fieldTypeManager
+     * @return TreeViewConfiguration
+     */
+    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface
+    {
+        return new TreeViewConfiguration($fieldable, $fieldTypeManager, $this->maxQueryLimit);
+    }
+}

--- a/src/Bundle/CoreBundle/View/Types/Factories/TreeViewConfigurationFactory.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/TreeViewConfigurationFactory.php
@@ -10,19 +10,20 @@ use UniteCMS\CoreBundle\View\Types\TreeViewConfiguration;
 class TreeViewConfigurationFactory implements ViewConfigurationFactoryInterface
 {
     protected $maxQueryLimit;
+    protected $fieldTypeManager;
 
-    public function __construct(int $maxQueryLimit)
+    public function __construct(FieldTypeManager $fieldTypeManager, int $maxQueryLimit)
     {
+        $this->fieldTypeManager = $fieldTypeManager;
         $this->maxQueryLimit = $maxQueryLimit;
     }
 
     /**
      * @param Fieldable $fieldable
-     * @param FieldTypeManager $fieldTypeManager
      * @return TreeViewConfiguration
      */
-    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface
+    public function create(Fieldable $fieldable): ConfigurationInterface
     {
-        return new TreeViewConfiguration($fieldable, $fieldTypeManager, $this->maxQueryLimit);
+        return new TreeViewConfiguration($fieldable, $this->fieldTypeManager, $this->maxQueryLimit);
     }
 }

--- a/src/Bundle/CoreBundle/View/Types/Factories/ViewConfigurationFactoryInterface.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/ViewConfigurationFactoryInterface.php
@@ -3,15 +3,13 @@
 namespace UniteCMS\CoreBundle\View\Types\Factories;
 
 use UniteCMS\CoreBundle\Entity\Fieldable;
-use UniteCMS\CoreBundle\Field\FieldTypeManager;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 interface ViewConfigurationFactoryInterface
 {
     /**
      * @param Fieldable $fieldable
-     * @param FieldTypeManager $fieldTypeManager
      * @return ConfigurationInterface
      */
-    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface;
+    public function create(Fieldable $fieldable): ConfigurationInterface;
 }

--- a/src/Bundle/CoreBundle/View/Types/Factories/ViewConfigurationFactoryInterface.php
+++ b/src/Bundle/CoreBundle/View/Types/Factories/ViewConfigurationFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace UniteCMS\CoreBundle\View\Types\Factories;
+
+use UniteCMS\CoreBundle\Entity\Fieldable;
+use UniteCMS\CoreBundle\Field\FieldTypeManager;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+interface ViewConfigurationFactoryInterface
+{
+    /**
+     * @param Fieldable $fieldable
+     * @param FieldTypeManager $fieldTypeManager
+     * @return ConfigurationInterface
+     */
+    public function create(Fieldable $fieldable, FieldTypeManager $fieldTypeManager): ConfigurationInterface;
+}

--- a/src/Bundle/CoreBundle/View/Types/GridViewType.php
+++ b/src/Bundle/CoreBundle/View/Types/GridViewType.php
@@ -2,15 +2,8 @@
 
 namespace UniteCMS\CoreBundle\View\Types;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use UniteCMS\CoreBundle\Entity\ContentType;
-
 class GridViewType extends TableViewType
 {
     const TYPE = "grid";
     const TEMPLATE = "UniteCMSCoreBundle:Views:Grid/index.html.twig";
-
-    protected function createConfig(ContentType $contentType) : ConfigurationInterface {
-        return new GridViewConfiguration($contentType, $this->fieldTypeManager);
-    }
 }

--- a/src/Bundle/CoreBundle/View/Types/TableViewConfiguration.php
+++ b/src/Bundle/CoreBundle/View/Types/TableViewConfiguration.php
@@ -58,6 +58,7 @@ class TableViewConfiguration implements ConfigurationInterface
             ->children()
                 ->append($this->appendFieldsNode())
                 ->append($this->appendFilterNode())
+                ->append($this->appendRowsPerPageNode())
                 ->append($this->appendSortNode())
                 ->append($this->appendActionsNode())
                 ->variableNode('sort_field')->setDeprecated()->end()
@@ -110,6 +111,24 @@ class TableViewConfiguration implements ConfigurationInterface
                         }
 
                         if (!$filter_structure->getFilter()) {
+                            throw $exception;
+                        }
+
+                        return $v;
+                    }
+                )
+            ->end();
+    }
+
+    protected function appendRowsPerPageNode() : VariableNodeDefinition {
+        $treeBuilder = new TreeBuilder('rows_per_page', 'scalar');
+        return $treeBuilder->getRootNode()
+            ->validate()
+                ->always(
+                    function ($v) {
+                        if (!is_int($v)) {
+                            $exception = new InvalidConfigurationException('Invalid rows_per_page configuration - must be an integer');
+                            $exception->setPath('rows_per_page');
                             throw $exception;
                         }
 

--- a/src/Bundle/CoreBundle/View/Types/TableViewConfiguration.php
+++ b/src/Bundle/CoreBundle/View/Types/TableViewConfiguration.php
@@ -36,10 +36,16 @@ class TableViewConfiguration implements ConfigurationInterface
      */
     protected $fieldTypeManager;
 
-    public function __construct(Fieldable $fieldable, FieldTypeManager $fieldTypeManager)
+    /**
+     * @var int $maxQueryLimit
+     */
+    protected $maxQueryLimit;
+
+    public function __construct(Fieldable $fieldable, FieldTypeManager $fieldTypeManager, int $maxQueryLimit = 100)
     {
         $this->fieldable = $fieldable;
         $this->fieldTypeManager = $fieldTypeManager;
+        $this->maxQueryLimit = $maxQueryLimit;
     }
 
     /**
@@ -128,6 +134,14 @@ class TableViewConfiguration implements ConfigurationInterface
                     function ($v) {
                         if (!is_int($v)) {
                             $exception = new InvalidConfigurationException('Invalid rows_per_page configuration - must be an integer');
+                            $exception->setPath('rows_per_page');
+                            throw $exception;
+                        }
+
+                        if ($v > $this->maxQueryLimit) {
+                            $exception = new InvalidConfigurationException(
+                                "Invalid rows_per_page configuration - must be within max_query_limit of {$this->maxQueryLimit}"
+                            );
                             $exception->setPath('rows_per_page');
                             throw $exception;
                         }

--- a/src/Bundle/CoreBundle/View/Types/TableViewType.php
+++ b/src/Bundle/CoreBundle/View/Types/TableViewType.php
@@ -8,7 +8,6 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use UniteCMS\CoreBundle\Entity\ContentType;
 use UniteCMS\CoreBundle\Entity\View;
 use UniteCMS\CoreBundle\Exception\DeprecationException;
-use UniteCMS\CoreBundle\Field\FieldTypeManager;
 use UniteCMS\CoreBundle\SchemaType\IdentifierNormalizer;
 use UniteCMS\CoreBundle\Validator\Constraints\Warning;
 use UniteCMS\CoreBundle\View\Types\Factories\ViewConfigurationFactoryInterface;
@@ -19,25 +18,18 @@ class TableViewType extends ViewType
 {
     const TYPE = "table";
     const TEMPLATE = "UniteCMSCoreBundle:Views:Table/index.html.twig";
-
     /**
-     * @var FieldTypeManager $fieldTypeManager
+     * @var ViewConfigurationFactoryInterface $viewConfigurationFactory;
      */
-    protected $fieldTypeManager;
+    protected $viewConfigurationFactory;
 
-    /**
-     * @var ViewConfigurationFactoryInterface $tableViewConfigurationFactory;
-     */
-    protected $tableViewConfigurationFactory;
-
-    public function __construct(FieldTypeManager $fieldTypeManager, ViewConfigurationFactoryInterface $tableViewConfigurationFactory)
+    public function __construct(ViewConfigurationFactoryInterface $viewConfigurationFactory)
     {
-        $this->fieldTypeManager = $fieldTypeManager;
-        $this->tableViewConfigurationFactory = $tableViewConfigurationFactory;
+        $this->viewConfigurationFactory = $viewConfigurationFactory;
     }
 
-    protected function createConfig(ContentType $contentType) : ConfigurationInterface {
-        return $this->tableViewConfigurationFactory->create($contentType, $this->fieldTypeManager);
+    protected function createConfig(ContentType $contentType): ConfigurationInterface {
+        return $this->viewConfigurationFactory->create($contentType);
     }
 
     /**

--- a/src/Bundle/CoreBundle/View/Types/TableViewType.php
+++ b/src/Bundle/CoreBundle/View/Types/TableViewType.php
@@ -11,6 +11,7 @@ use UniteCMS\CoreBundle\Exception\DeprecationException;
 use UniteCMS\CoreBundle\Field\FieldTypeManager;
 use UniteCMS\CoreBundle\SchemaType\IdentifierNormalizer;
 use UniteCMS\CoreBundle\Validator\Constraints\Warning;
+use UniteCMS\CoreBundle\View\Types\Factories\ViewConfigurationFactoryInterface;
 use UniteCMS\CoreBundle\View\ViewSettings;
 use UniteCMS\CoreBundle\View\ViewType;
 
@@ -24,13 +25,19 @@ class TableViewType extends ViewType
      */
     protected $fieldTypeManager;
 
-    public function __construct(FieldTypeManager $fieldTypeManager)
+    /**
+     * @var ViewConfigurationFactoryInterface $tableViewConfigurationFactory;
+     */
+    protected $tableViewConfigurationFactory;
+
+    public function __construct(FieldTypeManager $fieldTypeManager, ViewConfigurationFactoryInterface $tableViewConfigurationFactory)
     {
         $this->fieldTypeManager = $fieldTypeManager;
+        $this->tableViewConfigurationFactory = $tableViewConfigurationFactory;
     }
 
     protected function createConfig(ContentType $contentType) : ConfigurationInterface {
-        return new TableViewConfiguration($contentType, $this->fieldTypeManager);
+        return $this->tableViewConfigurationFactory->create($contentType, $this->fieldTypeManager);
     }
 
     /**

--- a/src/Bundle/CoreBundle/View/Types/TreeViewConfiguration.php
+++ b/src/Bundle/CoreBundle/View/Types/TreeViewConfiguration.php
@@ -35,6 +35,7 @@ class TreeViewConfiguration extends TableViewConfiguration
                 ->append($this->appendChildrenFieldNode())
                 ->append($this->appendFieldsNode())
                 ->append($this->appendFilterNode())
+                ->append($this->appendRowsPerPageNode())
                 ->append($this->appendSortNode())
             ->end();
 

--- a/src/Bundle/CoreBundle/View/Types/TreeViewType.php
+++ b/src/Bundle/CoreBundle/View/Types/TreeViewType.php
@@ -2,18 +2,12 @@
 
 namespace UniteCMS\CoreBundle\View\Types;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use UniteCMS\CoreBundle\Entity\ContentType;
 use UniteCMS\CoreBundle\Entity\View;
 
 class TreeViewType extends TableViewType
 {
     const TYPE = "tree";
     const TEMPLATE = "UniteCMSCoreBundle:Views:Tree/index.html.twig";
-
-    protected function createConfig(ContentType $contentType) : ConfigurationInterface {
-        return new TreeViewConfiguration($contentType, $this->fieldTypeManager);
-    }
 
     protected function addRecursiveChildrenFields($fields, $children_field, $sort, $level = 6) {
         return array_merge($fields, [

--- a/src/Bundle/VariantsFieldBundle/Field/Types/VariantsFieldType.php
+++ b/src/Bundle/VariantsFieldBundle/Field/Types/VariantsFieldType.php
@@ -472,7 +472,7 @@ class VariantsFieldType extends FieldType implements NestableFieldTypeInterface
             foreach($settings['settings']['on'] as $v => $fields) {
                 $processor = new Processor();
                 $variant = new Variant(null, $variants->getFieldsForVariant($v), $v, $v, $variants);
-                $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create($variant, $fieldTypeManager), ['settings' => ['fields' => $fields]]);
+                $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create($variant), ['settings' => ['fields' => $fields]]);
                 $settings['settings']['on'][$v] = $config['fields'];
                 $settings['settings']['variant_schema_types'][$v] = VariantFactory::schemaTypeNameForVariant($variant);
 

--- a/src/Bundle/VariantsFieldBundle/Field/Types/VariantsFieldType.php
+++ b/src/Bundle/VariantsFieldBundle/Field/Types/VariantsFieldType.php
@@ -19,7 +19,7 @@ use UniteCMS\CoreBundle\Field\FieldType;
 use UniteCMS\CoreBundle\Field\FieldTypeManager;
 use UniteCMS\CoreBundle\Field\NestableFieldTypeInterface;
 use UniteCMS\CoreBundle\SchemaType\SchemaTypeManager;
-use UniteCMS\CoreBundle\View\Types\TableViewConfiguration;
+use UniteCMS\CoreBundle\View\Types\Factories\ViewConfigurationFactoryInterface;
 use UniteCMS\VariantsFieldBundle\Form\VariantsFormType;
 use UniteCMS\VariantsFieldBundle\Model\Variant;
 use UniteCMS\VariantsFieldBundle\Model\VariantContent;
@@ -43,10 +43,16 @@ class VariantsFieldType extends FieldType implements NestableFieldTypeInterface
      */
     private $variantFactory;
 
-    function __construct(FieldTypeManager $fieldTypeManager, VariantFactory $variantFactory)
+    /**
+     * @var ViewConfigurationFactoryInterface $tableViewConfigurationFactory;
+     */
+    protected $tableViewConfigurationFactory;
+
+    function __construct(FieldTypeManager $fieldTypeManager, VariantFactory $variantFactory, ViewConfigurationFactoryInterface $tableViewConfigurationFactory)
     {
         $this->fieldTypeManager = $fieldTypeManager;
         $this->variantFactory = $variantFactory;
+        $this->tableViewConfigurationFactory = $tableViewConfigurationFactory;
     }
 
     /**
@@ -466,7 +472,7 @@ class VariantsFieldType extends FieldType implements NestableFieldTypeInterface
             foreach($settings['settings']['on'] as $v => $fields) {
                 $processor = new Processor();
                 $variant = new Variant(null, $variants->getFieldsForVariant($v), $v, $v, $variants);
-                $config = $processor->processConfiguration(new TableViewConfiguration($variant, $fieldTypeManager), ['settings' => ['fields' => $fields]]);
+                $config = $processor->processConfiguration($this->tableViewConfigurationFactory->create($variant, $fieldTypeManager), ['settings' => ['fields' => $fields]]);
                 $settings['settings']['on'][$v] = $config['fields'];
                 $settings['settings']['variant_schema_types'][$v] = VariantFactory::schemaTypeNameForVariant($variant);
 

--- a/src/Bundle/VariantsFieldBundle/Resources/config/services.yml
+++ b/src/Bundle/VariantsFieldBundle/Resources/config/services.yml
@@ -4,7 +4,7 @@ services:
   UniteCMS\VariantsFieldBundle\Field\Types\VariantsFieldType:
     tags: [unite_cms.field_type]
     arguments:
-      ['@unite.cms.field_type_manager', '@unite.cms.graphql.variants_field_variant_factory']
+      ['@unite.cms.field_type_manager', '@unite.cms.graphql.variants_field_variant_factory', '@unite.cms.field_type.config_factory.table_view']
 
   # A form type that renders a variant choice field and all variants.
   UniteCMS\VariantsFieldBundle\Form\VariantsFormType:

--- a/src/Bundle/VariantsFieldBundle/Tests/NestedFieldAlterTest.php
+++ b/src/Bundle/VariantsFieldBundle/Tests/NestedFieldAlterTest.php
@@ -31,7 +31,7 @@ class NestedFieldAlterTest extends TestCase
             new VariantsFieldType(
                 $manager,
                 $this->createMock(VariantFactory::class),
-                new TableViewConfigurationFactory(100)
+                new TableViewConfigurationFactory($manager, 100)
             )
         );
         $manager->registerFieldType(new class extends FieldType {

--- a/src/Bundle/VariantsFieldBundle/Tests/NestedFieldAlterTest.php
+++ b/src/Bundle/VariantsFieldBundle/Tests/NestedFieldAlterTest.php
@@ -17,6 +17,7 @@ use UniteCMS\CoreBundle\Entity\FieldableField;
 use UniteCMS\CoreBundle\Field\FieldableFieldSettings;
 use UniteCMS\CoreBundle\Field\FieldType;
 use UniteCMS\CoreBundle\Field\FieldTypeManager;
+use UniteCMS\CoreBundle\View\Types\Factories\TableViewConfigurationFactory;
 use UniteCMS\VariantsFieldBundle\Field\Types\VariantsFieldType;
 use UniteCMS\VariantsFieldBundle\SchemaType\Factories\VariantFactory;
 
@@ -26,7 +27,13 @@ class NestedFieldAlterTest extends TestCase
 
         $manager = new FieldTypeManager();
 
-        $manager->registerFieldType(new VariantsFieldType($manager, $this->createMock(VariantFactory::class)));
+        $manager->registerFieldType(
+            new VariantsFieldType(
+                $manager,
+                $this->createMock(VariantFactory::class),
+                new TableViewConfigurationFactory(100)
+            )
+        );
         $manager->registerFieldType(new class extends FieldType {
             const TYPE = 't_f1';
             public function alterData(FieldableField $field, &$data, FieldableContent $content, $rootData) { $data[$field->getIdentifier()] = 'FOO'; }


### PR DESCRIPTION
This setting controls how many rows are rendered per page. Previously
this was hard-coded to 10, which caused problems for tree views - it
isn't possible to drag items from one page to another, so all the top-
level items need to fit on one page.

The `rows_per_page` setting is optional, and will default to 10 if not
specified. If specified, it must be an integer - floats and strings
are not accepted. An example of config using the setting:

```
{
  "content_types": [
    {
      "title": "Categories",
      "identifier": "category",
      "fields": [ ... ],
      "views": [
        {
          "title": "All",
          "identifier": "all",
          "type": "table",
          "settings": {
            "fields": { ... },
            "rows_per_page": 20
          }
        }
      ]
    }
  ]
}
```