### PR TITLE
fix #496 [VariantsFieldBundle]: Dump all child assets on variants fie…

### DIFF
--- a/src/Bundle/VariantsFieldBundle/Resources/views/Form/form_widgets.html.twig
+++ b/src/Bundle/VariantsFieldBundle/Resources/views/Form/form_widgets.html.twig
@@ -1,4 +1,5 @@
 {%- block unite_cms_variants_widget -%}
+    {{ include('@UniteCMSCore/Form/_recursive_asset_dumper.html.twig', { form: form }) }}
     {% set input_selector = form.type.vars.full_name %}
     {% for key, child in form.children %}
         {% if key == 'type' %}


### PR DESCRIPTION
…lds before field gets rendered, instead of having them only added on choice select