### PR TITLE
 Make S3 credentials optional, add ACL bucket setting

### DIFF
--- a/src/Bundle/StorageBundle/Field/Types/FileFieldType.php
+++ b/src/Bundle/StorageBundle/Field/Types/FileFieldType.php
@@ -162,7 +162,7 @@ class FileFieldType extends FieldType
         // Validate allowed bucket configuration.
         if($context->getViolations()->count() == 0) {
             foreach($settings->bucket as $field => $value) {
-                if(!in_array($field, ['endpoint', 'key', 'secret', 'bucket', 'path', 'region'])) {
+                if(!in_array($field, ['endpoint', 'key', 'secret', 'bucket', 'path', 'region', 'acl'])) {
                     $context->buildViolation('additional_data')->atPath('bucket.' . $field)->addViolation();
                 }
             }

--- a/src/Bundle/StorageBundle/Field/Types/FileFieldType.php
+++ b/src/Bundle/StorageBundle/Field/Types/FileFieldType.php
@@ -170,7 +170,7 @@ class FileFieldType extends FieldType
 
         // Validate required bucket configuration.
         if($context->getViolations()->count() == 0) {
-            foreach(['endpoint', 'key', 'secret', 'bucket'] as $required_field) {
+            foreach(['endpoint', 'bucket'] as $required_field) {
                 if(!isset($settings->bucket[$required_field])) {
                     $context->buildViolation('required')->atPath('bucket.' . $required_field)->addViolation();
                 }

--- a/src/Bundle/StorageBundle/Service/StorageService.php
+++ b/src/Bundle/StorageBundle/Service/StorageService.php
@@ -139,13 +139,14 @@ class StorageService
             }
         }
 
-        $command = $s3Client->getCommand(
-            'PutObject',
-            [
-                'Bucket' => $bucket_settings['bucket'],
-                'Key' => $filePath,
-            ]
-        );
+        $putObjectParams = [
+            'Bucket' => $bucket_settings['bucket'],
+            'Key' => $filePath,
+        ];
+        if (isset($bucket_settings['acl'])) {
+            $putObjectParams['ACL'] = $bucket_settings['acl'];
+        }
+        $command = $s3Client->getCommand('PutObject', $putObjectParams);
 
         return new PreSignedUrl(
             (string)$s3Client->createPresignedRequest($command, '+5 minutes')

--- a/src/Bundle/StorageBundle/Service/StorageService.php
+++ b/src/Bundle/StorageBundle/Service/StorageService.php
@@ -111,18 +111,22 @@ class StorageService
         $uuid = (string)Uuid::uuid1();
 
         // Return pre-signed url
-        $s3Client = new S3Client(
-            [
-                'version' => 'latest',
-                'region' => $bucket_settings['region'] ?? 'us-east-1',
-                'endpoint' => $bucket_settings['endpoint'],
-                'use_path_style_endpoint' => true,
-                'credentials' => [
-                    'key' => $bucket_settings['key'],
-                    'secret' => $bucket_settings['secret'],
-                ],
-            ]
-        );
+        $s3Config = [
+            'version' => 'latest',
+            'region' => $bucket_settings['region'] ?? 'us-east-1',
+            'endpoint' => $bucket_settings['endpoint'],
+            'use_path_style_endpoint' => true,
+        ];
+        // The key and secret are optional - if they're not specified, the S3 client
+        // object will attempt to fetch them from the EC2 instance metadata server.
+        if (isset($bucket_settings['key']) && isset($bucket_settings['secret'])) {
+            $s3Config['credentials'] = [
+                'key' => $bucket_settings['key'],
+                'secret' => $bucket_settings['secret'],
+            ];
+        }
+
+        $s3Client = new S3Client($s3Config);
 
         // Set the upload file path to an optional path + uuid + filename.
         $filePath = $uuid.'/'.$filename;
@@ -206,18 +210,22 @@ class StorageService
      */
     public function deleteObject(string $uuid, string $filename, array $bucket_settings)
     {
-        $s3Client = new S3Client(
-            [
-                'version' => 'latest',
-                'region' => $bucket_settings['region'] ?? 'us-east-1',
-                'endpoint' => $bucket_settings['endpoint'],
-                'use_path_style_endpoint' => true,
-                'credentials' => [
-                    'key' => $bucket_settings['key'],
-                    'secret' => $bucket_settings['secret'],
-                ],
-            ]
-        );
+        $s3Config = [
+            'version' => 'latest',
+            'region' => $bucket_settings['region'] ?? 'us-east-1',
+            'endpoint' => $bucket_settings['endpoint'],
+            'use_path_style_endpoint' => true
+        ];
+        // The key and secret are optional - if they're not specified, the S3 client
+        // object will attempt to fetch them from the EC2 instance metadata server.
+        if (isset($bucket_settings['key']) && isset($bucket_settings['secret'])) {
+            $s3Config['credentials'] = [
+                'key' => $bucket_settings['key'],
+                'secret' => $bucket_settings['secret'],
+            ];
+        }
+
+        $s3Client = new S3Client($s3Config);
 
         // Set the upload file path to an optional path + uuid + filename.
         $filePath = $uuid.'/'.$filename;

--- a/src/Bundle/StorageBundle/Tests/FileFieldTypeTest.php
+++ b/src/Bundle/StorageBundle/Tests/FileFieldTypeTest.php
@@ -48,15 +48,11 @@ class FileFieldTypeTest extends FieldTypeTestCase
         );
 
         $errors = static::$container->get('validator')->validate($field);
-        $this->assertCount(4, $errors);
+        $this->assertCount(2, $errors);
         $this->assertEquals('settings.bucket.endpoint', $errors->get(0)->getPropertyPath());
         $this->assertEquals('required', $errors->get(0)->getMessageTemplate());
-        $this->assertEquals('settings.bucket.key', $errors->get(1)->getPropertyPath());
+        $this->assertEquals('settings.bucket.bucket', $errors->get(1)->getPropertyPath());
         $this->assertEquals('required', $errors->get(1)->getMessageTemplate());
-        $this->assertEquals('settings.bucket.secret', $errors->get(2)->getPropertyPath());
-        $this->assertEquals('required', $errors->get(2)->getMessageTemplate());
-        $this->assertEquals('settings.bucket.bucket', $errors->get(3)->getPropertyPath());
-        $this->assertEquals('required', $errors->get(3)->getMessageTemplate());
 
         $field->setSettings(
             new FieldableFieldSettings(
@@ -67,6 +63,7 @@ class FileFieldTypeTest extends FieldTypeTestCase
                         'key' => 'XXX',
                         'secret' => 'XXX',
                         'bucket' => 'foo',
+                        'acl' => 'public-read',
                     ],
                 ]
             )
@@ -87,6 +84,7 @@ class FileFieldTypeTest extends FieldTypeTestCase
                         'secret' => 'XXX',
                         'bucket' => 'foo',
                         "path" => "/any",
+                        'acl' => 'public-read',
                     ],
                 ]
             )
@@ -106,6 +104,7 @@ class FileFieldTypeTest extends FieldTypeTestCase
                         'secret' => 'XXX',
                         'bucket' => 'foo',
                         "region" => "east",
+                        'acl' => 'public-read',
                     ],
                 ]
             )
@@ -126,6 +125,7 @@ class FileFieldTypeTest extends FieldTypeTestCase
                         'bucket' => 'foo',
                         "region" => "east",
                         "path" => "/any",
+                        'acl' => 'public-read',
                         'foo' => 'baa',
                     ],
                 ]

--- a/src/Bundle/StorageBundle/Tests/ImageFieldTypeTest.php
+++ b/src/Bundle/StorageBundle/Tests/ImageFieldTypeTest.php
@@ -44,15 +44,11 @@ class ImageFieldTypeTest extends FieldTypeTestCase
         );
 
         $errors = static::$container->get('validator')->validate($field);
-        $this->assertCount(4, $errors);
+        $this->assertCount(2, $errors);
         $this->assertEquals('settings.bucket.endpoint', $errors->get(0)->getPropertyPath());
         $this->assertEquals('required', $errors->get(0)->getMessageTemplate());
-        $this->assertEquals('settings.bucket.key', $errors->get(1)->getPropertyPath());
+        $this->assertEquals('settings.bucket.bucket', $errors->get(1)->getPropertyPath());
         $this->assertEquals('required', $errors->get(1)->getMessageTemplate());
-        $this->assertEquals('settings.bucket.secret', $errors->get(2)->getPropertyPath());
-        $this->assertEquals('required', $errors->get(2)->getMessageTemplate());
-        $this->assertEquals('settings.bucket.bucket', $errors->get(3)->getPropertyPath());
-        $this->assertEquals('required', $errors->get(3)->getMessageTemplate());
 
         $field->setSettings(
             new FieldableFieldSettings(


### PR DESCRIPTION
The `key` and `secret` bucket settings for file and image fields are
no longer required. If they're not specified, the S3 client will
automatically attempt to retrieve credentials from the EC2 instance
metadata server. This allows the EC2 instance role to be granted the
required S3 permissions, rather than having to add the key and secret
to the Unite domain configuration.

Also add an `acl` bucket setting to file and image fields This allows
setting an S3 canned ACL on uploaded files. The main use for this is
automatically applying the `public-read` ACL to uploaded files that
should be publicly accessible.

Note that the IAM user credentials need to have the `s3:PutObjectAcl`
permission to use this feature.