### PR TITLE
Fix nested cards width at 2100px+

### DIFF
--- a/src/Bundle/CoreBundle/Resources/webpack/sass/components/_cards.scss
+++ b/src/Bundle/CoreBundle/Resources/webpack/sass/components/_cards.scss
@@ -160,7 +160,7 @@
 @media (min-width: 2100px) {
   .uk-card.full-content-card {
     &:not(.always-full) {
-      width: 1600px;
+      min-width: 1550px;
       align-self: center;
     }
   }


### PR DESCRIPTION
At widths of 2100px or higher, nested elements with the `uk-card`
class will overflow to the right their parents. This is due to a fixed
width of 1600px. Setting a `min-width` resolves this by allowing the
outer pane to grow to be wider than the inner pane.