### PR TITLE
Resolves #407 - Add hidden field setting 

### DIFF
--- a/src/Bundle/CoreBundle/Field/FieldType.php
+++ b/src/Bundle/CoreBundle/Field/FieldType.php
@@ -27,7 +27,7 @@ abstract class FieldType implements FieldTypeInterface
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default'];
+    const SETTINGS = ['not_empty', 'description', 'hidden', 'default'];
 
     /**
      * All required settings for this field type.
@@ -60,6 +60,7 @@ abstract class FieldType implements FieldTypeInterface
             'required' => false,
             'not_empty' => (isset($field->getSettings()->not_empty)) ? (boolean) $field->getSettings()->not_empty : false,
             'description' => (isset($field->getSettings()->description)) ? (string) $field->getSettings()->description : '',
+            'hidden' => (isset($field->getSettings()->hidden)) ? (boolean) $field->getSettings()->hidden: false,
         ];
     }
 
@@ -148,6 +149,13 @@ abstract class FieldType implements FieldTypeInterface
         if (!empty($settingsArray['not_empty'])) {
             $context->getViolations()->addAll(
                 $context->getValidator()->validate($settingsArray['not_empty'], new Assert\Type(['type' => 'boolean', 'message' => 'noboolean_value']))
+            );
+        }
+
+        // validate hidden is boolean
+        if (!empty($settingsArray['hidden'])) {
+            $context->getViolations()->addAll(
+                $context->getValidator()->validate($settingsArray['hidden'], new Assert\Type(['type' => 'boolean', 'message' => 'noboolean_value']))
             );
         }
 

--- a/src/Bundle/CoreBundle/Field/Types/CheckboxFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/CheckboxFieldType.php
@@ -16,7 +16,7 @@ class CheckboxFieldType extends FieldType
 {
     const TYPE = "checkbox";
     const FORM_TYPE = CheckboxType::class;
-    const SETTINGS = ['default', 'description'];
+    const SETTINGS = ['default', 'description', 'hidden'];
 
     /**
      * {@inheritdoc}
@@ -50,5 +50,33 @@ class CheckboxFieldType extends FieldType
     function resolveGraphQLData(FieldableField $field, $value, FieldableContent $content)
     {
         return (boolean)$value;
+    }
+
+    /**
+     * Basic settings validation based on self::SETTINGS and self::REQUIRED_SETTINGS constants. More sophisticated
+     * validation should be done in child implementations.
+     *
+     * @param FieldableFieldSettings $settings
+     * @param ExecutionContextInterface $context
+     *
+     */
+    function validateSettings(FieldableFieldSettings $settings, ExecutionContextInterface $context)
+    {
+        // Validate allowed and required settings.
+        parent::validateSettings($settings, $context);
+
+        // Only continue, if there are no violations yet.
+        if($context->getViolations()->count() > 0) {
+            return;
+        }
+
+        $settingsArray = $settings ? get_object_vars($settings) : [];
+
+        // validate hidden is boolean
+        if (!empty($settingsArray['hidden'])) {
+            $context->getViolations()->addAll(
+                $context->getValidator()->validate($settingsArray['hidden'], new Assert\Type(['type' => 'boolean', 'message' => 'noboolean_value']))
+            );
+        }
     }
 }

--- a/src/Bundle/CoreBundle/Field/Types/RangeFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/RangeFieldType.php
@@ -17,7 +17,7 @@ class RangeFieldType extends FieldType
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default', 'min', 'max', 'step'];
+    const SETTINGS = ['not_empty', 'description', 'default', 'min', 'max', 'step', 'hidden'];
 
     function getFormOptions(FieldableField $field): array
     {
@@ -28,6 +28,7 @@ class RangeFieldType extends FieldType
                     'min' => $field->getSettings()->min ?? 0,
                     'max' => $field->getSettings()->max ?? 100,
                     'step' => $field->getSettings()->step ?? 1,
+                    'hidden' => $field->getSettings()->hidden ?? false,
                 ],
             ]
         );

--- a/src/Bundle/CoreBundle/Field/Types/ReferenceFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/ReferenceFieldType.php
@@ -39,7 +39,7 @@ class ReferenceFieldType extends FieldType
 {
     const TYPE = "reference";
     const FORM_TYPE = ReferenceType::class;
-    const SETTINGS = ['not_empty', 'description', 'domain', 'content_type', 'view', 'content_label'];
+    const SETTINGS = ['not_empty', 'description', 'domain', 'content_type', 'view', 'content_label', 'hidden'];
     const REQUIRED_SETTINGS = ['domain', 'content_type'];
 
     /**

--- a/src/Bundle/CoreBundle/Field/Types/SortIndexFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/SortIndexFieldType.php
@@ -15,7 +15,7 @@ class SortIndexFieldType extends FieldType
 {
     const TYPE = "sortindex";
     const FORM_TYPE = IntegerType::class;
-    const SETTINGS = ['description'];
+    const SETTINGS = ['description', 'hidden'];
 
     function getGraphQLType(FieldableField $field, SchemaTypeManager $schemaTypeManager, $nestingLevel = 0)
     {

--- a/src/Bundle/CoreBundle/Field/Types/TextAreaFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/TextAreaFieldType.php
@@ -18,7 +18,7 @@ class TextAreaFieldType extends FieldType
     /**
      * All settings of this field type by key with optional default value.
      */
-    const SETTINGS = ['not_empty', 'description', 'default', 'rows'];
+    const SETTINGS = ['not_empty', 'description', 'default', 'rows', 'hidden'];
 
     function getFormOptions(FieldableField $field): array
     {
@@ -26,7 +26,8 @@ class TextAreaFieldType extends FieldType
             parent::getFormOptions($field),
               [
                 'attr' => [
-                    'rows' => $field->getSettings()->rows ?? 2
+                    'rows' => $field->getSettings()->rows ?? 2,
+                    'hidden' => $field->getSettings()->hidden ?? false
                 ],
               ]
         );

--- a/src/Bundle/CoreBundle/Form/AutoTextType.php
+++ b/src/Bundle/CoreBundle/Form/AutoTextType.php
@@ -56,6 +56,7 @@ class AutoTextType extends AbstractType
                 'label' => $options['label'],
                 'not_empty' => $options['not_empty'],
                 'error_bubbling' => true,
+                'hidden' => $options['hidden'],
             ])
             ->add('auto', CheckboxType::class, ['label' => $options['label']]);
     }

--- a/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
+++ b/src/Bundle/CoreBundle/Form/Extension/UniteCMSCoreTypeExtension.php
@@ -64,6 +64,10 @@ class UniteCMSCoreTypeExtension extends AbstractTypeExtension
             $view->vars['description'] = $options['description'];
         }
 
+        // pass hidden to template
+        if (isset($options['hidden'])) {
+            $view->vars['hidden'] = $options['hidden'];
+        }
     }
 
     /**
@@ -74,6 +78,7 @@ class UniteCMSCoreTypeExtension extends AbstractTypeExtension
         $resolver->setDefined('description');
         $resolver->setDefined('default');
         $resolver->setDefined('not_empty');
+        $resolver->setDefined('hidden');
 
         // If not_empty is set, also set the required option to true
         $resolver->setNormalizer('required', function(Options $options, $value){

--- a/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
+++ b/src/Bundle/CoreBundle/Resources/views/Form/uikit_layout.html.twig
@@ -16,7 +16,7 @@
 
 {%- block form_row -%}
     {% if block_prefixes[1] is defined and block_prefixes[1] == 'checkbox' %}
-        <div class="uk-margin">
+        <div class="uk-margin"{% if form.vars.hidden is defined and form.vars.hidden == true %} hidden{%- endif -%}>
             <div class="uk-form-controls uk-form-controls-text uk-form-controls-checkbox">
                 {{- form_widget(form) -}}
             </div>
@@ -26,7 +26,7 @@
             {{- form_errors(form) -}}
         </div>
     {% elseif label is not same as(false) -%}
-        <div class="uk-margin">
+        <div class="uk-margin"{% if form.vars.hidden is defined and form.vars.hidden == true %} hidden{%- endif -%}>
             {{- form_label(form) -}}
             <div class="uk-form-controls">
                 {{- form_widget(form) -}}

--- a/src/Bundle/CoreBundle/Tests/Field/CheckboxFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/CheckboxFieldTypeTest.php
@@ -29,13 +29,15 @@ class CheckboxFieldTypeTest extends FieldTypeTestCase
         // validate wrong initial data
         $ctField->setSettings(new FieldableFieldSettings(
             [
-                'default' => 123
+                'default' => 123,
+                'hidden' => 123
             ]
         ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(1, $errors);
-        $this->assertEquals('invalid_initial_data', $errors->get(0)->getMessageTemplate());
+        $this->assertCount(2, $errors);
+        $this->assertEquals('noboolean_value', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('invalid_initial_data', $errors->get(1)->getMessageTemplate());
     }
 
     public function testFormSubmit() {
@@ -69,7 +71,8 @@ class CheckboxFieldTypeTest extends FieldTypeTestCase
         $ctField->setSettings(new FieldableFieldSettings(
             [
                 'default' => true,
-                'description' => 'blabla'
+                'description' => 'blabla',
+                'hidden' => false
             ]
         ));
 

--- a/src/Bundle/CoreBundle/Tests/Field/DateFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/DateFieldTypeTest.php
@@ -28,14 +28,16 @@ class DateFieldTypeTest extends FieldTypeTestCase
         $ctField->setSettings(new FieldableFieldSettings(
             [
                 'foo' => 'baa',
-                'not_empty' => 124
+                'not_empty' => 124,
+                'hidden' => 123
             ]
         ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(2, $errors);
+        $this->assertCount(3, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
         $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(2)->getMessageTemplate());
 
         // test wrong initial data
         $ctField->setSettings(new FieldableFieldSettings(
@@ -56,7 +58,8 @@ class DateFieldTypeTest extends FieldTypeTestCase
         $ctField->setSettings(new FieldableFieldSettings(
             [
                 'default' => '2018-05-24',
-                'not_empty' => true
+                'not_empty' => true,
+                'hidden' => true
             ]
         ));
 
@@ -72,7 +75,7 @@ class DateFieldTypeTest extends FieldTypeTestCase
         $id = new \ReflectionProperty($content, 'id');
         $id->setAccessible(true);
         $id->setValue($content, 1);
-        
+
         $form = static::$container->get('unite.cms.fieldable_form_builder')->createForm($ctField->getContentType(), $content, [
             'csrf_protection' => false,
         ]);

--- a/src/Bundle/CoreBundle/Tests/Field/DateTimeFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/DateTimeFieldTypeTest.php
@@ -26,13 +26,15 @@ class DateTimeFieldTypeTest extends FieldTypeTestCase
 
         $ctField->setSettings(new FieldableFieldSettings(
             [
+                'hidden' => 123,
                 'foo' => 'baa',
             ]
         ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(1, $errors);
+        $this->assertCount(2, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
 
         // test wrong initial data
         $ctField->setSettings(new FieldableFieldSettings(

--- a/src/Bundle/CoreBundle/Tests/Field/EmailFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/EmailFieldTypeTest.php
@@ -17,11 +17,17 @@ class EmailFieldTypeTest extends FieldTypeTestCase
     {
         // Email Type Field with invalid settings should not be valid.
         $ctField = $this->createContentTypeField('email');
-        $ctField->setSettings(new FieldableFieldSettings(['foo' => 'baa']));
+        $ctField->setSettings(new FieldableFieldSettings(
+            [
+                'hidden' => 123,
+                'foo' => 'baa'
+            ]
+        ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(1, $errors);
+        $this->assertCount(2, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
 
         $ctField->setSettings(new FieldableFieldSettings(['default' => 'baa.asdfasdf.at']));
 
@@ -37,6 +43,7 @@ class EmailFieldTypeTest extends FieldTypeTestCase
             [
                 'not_empty' => true,
                 'description' => 'my description',
+                'hidden' => true,
                 'default' => 'admin@unite.co.at'
             ]
         ));

--- a/src/Bundle/CoreBundle/Tests/Field/IntegerFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/IntegerFieldTypeTest.php
@@ -17,11 +17,17 @@ class IntegerFieldTypeTest extends FieldTypeTestCase
     {
         // Integer Type Field with invalid settings should not be valid.
         $ctField = $this->createContentTypeField('integer');
-        $ctField->setSettings(new FieldableFieldSettings(['foo' => 'baa']));
+        $ctField->setSettings(new FieldableFieldSettings(
+            [
+                'hidden' => 123,
+                'foo' => 'baa'
+            ]
+        ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(1, $errors);
+        $this->assertCount(2, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
 
         // test wrong initial data
         $ctField->setSettings(new FieldableFieldSettings(['default' => 'baa']));
@@ -38,6 +44,7 @@ class IntegerFieldTypeTest extends FieldTypeTestCase
             [
                 'not_empty' => true,
                 'description' => 'my description',
+                'hidden' => true,
                 'default' => 123
             ]
         ));

--- a/src/Bundle/CoreBundle/Tests/Field/NumberFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/NumberFieldTypeTest.php
@@ -17,11 +17,17 @@ class NumberFieldTypeTest extends FieldTypeTestCase
     {
         // Number Type Field with invalid settings should not be valid.
         $ctField = $this->createContentTypeField('number');
-        $ctField->setSettings(new FieldableFieldSettings(['foo' => 'baa']));
+        $ctField->setSettings(new FieldableFieldSettings(
+            [
+                'hidden' => 123,
+                'foo' => 'baa'
+            ]
+        ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(1, $errors);
+        $this->assertCount(2, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
 
         // test wrong initial data
         $ctField->setSettings(new FieldableFieldSettings(['default' => 'baa']));

--- a/src/Bundle/CoreBundle/Tests/Field/PhoneFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/PhoneFieldTypeTest.php
@@ -17,11 +17,17 @@ class PhoneFieldTypeTest extends FieldTypeTestCase
     {
         // Phone Type Field with invalid settings should not be valid.
         $ctField = $this->createContentTypeField('phone');
-        $ctField->setSettings(new FieldableFieldSettings(['foo' => 'baa']));
+        $ctField->setSettings(new FieldableFieldSettings(
+            [
+                'hidden' => 123,
+                'foo' => 'baa'
+            ]
+        ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(1, $errors);
+        $this->assertCount(2, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
 
         // test wrong intial data
         $ctField->setSettings(new FieldableFieldSettings(['default' => ['test']]));
@@ -39,6 +45,7 @@ class PhoneFieldTypeTest extends FieldTypeTestCase
             [
                 'not_empty' => true,
                 'description' => 'my description',
+                'hidden' => true,
                 'default' => '+436605277131'
             ]
         ));

--- a/src/Bundle/CoreBundle/Tests/Field/RangeFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/RangeFieldTypeTest.php
@@ -20,14 +20,14 @@ class RangeFieldTypeTest extends FieldTypeTestCase
 
         // Content Type Field with invalid settings should not be valid.
         $ctField = $this->createContentTypeField('range');
-        $ctField->setSettings(new FieldableFieldSettings(['min' => 0, 'max' => 100, 'step' => 1, 'foo' => 'baa']));
+        $ctField->setSettings(new FieldableFieldSettings(['min' => 0, 'max' => 100, 'step' => 1, 'hidden' => true, 'foo' => 'baa']));
 
         $errors = static::$container->get('validator')->validate($ctField);
         $this->assertCount(1, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
 
         // validate initial data
-        $ctField->setSettings(new FieldableFieldSettings(['min' => 0, 'max' => 100, 'step' => 1, 'default' => 'baa']));
+        $ctField->setSettings(new FieldableFieldSettings(['min' => 0, 'max' => 100, 'step' => 1, 'hidden' => true, 'default' => 'baa']));
 
         $errors = static::$container->get('validator')->validate($ctField);
         $this->assertCount(1, $errors);
@@ -39,7 +39,7 @@ class RangeFieldTypeTest extends FieldTypeTestCase
 
         // Content Type Field with invalid settings should not be valid.
         $ctField = $this->createContentTypeField('range');
-        $ctField->setSettings(new FieldableFieldSettings(['min' => 0, 'max' => 100, 'step' => 1, 'default' => 50]));
+        $ctField->setSettings(new FieldableFieldSettings(['min' => 0, 'max' => 100, 'step' => 1, 'hidden' => true, 'default' => 50]));
 
         $errors = static::$container->get('validator')->validate($ctField);
         $this->assertCount(0, $errors);

--- a/src/Bundle/CoreBundle/Tests/Field/SortIndexFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/SortIndexFieldTypeTest.php
@@ -8,6 +8,7 @@ use UniteCMS\CoreBundle\Entity\ContentType;
 use UniteCMS\CoreBundle\Entity\ContentTypeField;
 use UniteCMS\CoreBundle\Entity\Domain;
 use UniteCMS\CoreBundle\Entity\Organization;
+use UniteCMS\CoreBundle\Field\FieldableFieldSettings;
 
 class SortIndexFieldTypeTest extends FieldTypeTestCase
 {
@@ -17,6 +18,39 @@ class SortIndexFieldTypeTest extends FieldTypeTestCase
         $ctField = $this->createContentTypeField('sortindex');
         $this->assertCount(0, static::$container->get('validator')->validate($ctField));
     }
+
+    public function testSortIndexFieldTypeWithInvalidSettings()
+    {
+        // Sort Index Field with invalid settings should not be valid.
+        $ctField = $this->createContentTypeField('sortindex');
+        $ctField->setSettings(new FieldableFieldSettings(
+            [
+                'hidden' => 123,
+                'foo' => 'baa'
+            ]
+        ));
+
+        $errors = static::$container->get('validator')->validate($ctField);
+        $this->assertCount(2, $errors);
+        $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
+    }
+
+    public function testSortIndexFieldTypeWithValidSettings()
+    {
+        // Phone Type Field with invalid settings should not be valid.
+        $ctField = $this->createContentTypeField('sortindex');
+        $ctField->setSettings(new FieldableFieldSettings(
+            [
+                'description' => 'my description',
+                'hidden' => true
+            ]
+        ));
+
+        $errors = static::$container->get('validator')->validate($ctField);
+        $this->assertCount(0, $errors);
+    }
+
 
     public function testAutoUpdateSortIndexOnInsertUpdateDelete() {
 

--- a/src/Bundle/CoreBundle/Tests/Field/TextAreaTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/TextAreaTypeTest.php
@@ -64,15 +64,17 @@ class TextAreaTypeTest extends FieldTypeTestCase
           [
               'foo' => 'baa',
               'not_empty' => 'foo',
-              'description' => true
+              'description' => true,
+              'hidden' => 123
           ]
         ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(3, $errors);
+        $this->assertCount(4, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
         $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
-        $this->assertEquals('nostring_value', $errors->get(2)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(2)->getMessageTemplate());
+        $this->assertEquals('nostring_value', $errors->get(3)->getMessageTemplate());
 
         // test wrong initial data
         $ctField->setSettings(new FieldableFieldSettings(

--- a/src/Bundle/CoreBundle/Tests/Field/TextFieldTypeTest.php
+++ b/src/Bundle/CoreBundle/Tests/Field/TextFieldTypeTest.php
@@ -23,15 +23,17 @@ class TextFieldTypeTest extends FieldTypeTestCase
             [
                 'foo' => 'baa',
                 'not_empty' => 'foo',
-                'description' => $this->generateRandomMachineName(500)
+                'description' => $this->generateRandomMachineName(500),
+                'hidden' => 123
             ]
         ));
 
         $errors = static::$container->get('validator')->validate($ctField);
-        $this->assertCount(3, $errors);
+        $this->assertCount(4, $errors);
         $this->assertEquals('additional_data', $errors->get(0)->getMessageTemplate());
         $this->assertEquals('noboolean_value', $errors->get(1)->getMessageTemplate());
-        $this->assertEquals('too_long', $errors->get(2)->getMessageTemplate());
+        $this->assertEquals('noboolean_value', $errors->get(2)->getMessageTemplate());
+        $this->assertEquals('too_long', $errors->get(3)->getMessageTemplate());
 
          // test wrong initial data
         $ctField->setSettings(new FieldableFieldSettings(


### PR DESCRIPTION
If this setting is present and set to true, the field will be hidden
on forms. One use case is for a sort index field linked to a
drag-and-drop list interface. Dragging list items to change their
order will update the linked field, but we don't want the actual
position field visible to users.

An example field definition:
```
{
  "title": "Position",
  "identifier": "position",
  "type": "sortindex",
  "settings": {
    "hidden": true
  }
}
```