### PR TITLE
fix #582 [CoreBundle, VariantsFieldBundle]: sometimes one cannot iter…

### DIFF
--- a/src/Bundle/CoreBundle/Resources/views/Form/_recursive_asset_dumper.html.twig
+++ b/src/Bundle/CoreBundle/Resources/views/Form/_recursive_asset_dumper.html.twig
@@ -15,7 +15,7 @@
         {% endfor %}
     {% endif %}
     {% if form.children is defined and form.children is not empty %}
-        {% for child in form.children %}
+        {% for child in form %}
             {{ include('@UniteCMSCore/Form/_recursive_asset_dumper.html.twig', { form: child }) }}
         {% endfor %}
     {% endif %}

--- a/src/Bundle/VariantsFieldBundle/Resources/views/Form/form_widgets.html.twig
+++ b/src/Bundle/VariantsFieldBundle/Resources/views/Form/form_widgets.html.twig
@@ -1,7 +1,7 @@
 {%- block unite_cms_variants_widget -%}
     {{ include('@UniteCMSCore/Form/_recursive_asset_dumper.html.twig', { form: form }) }}
     {% set input_selector = form.type.vars.full_name %}
-    {% for key, child in form.children %}
+    {% for key, child in form %}
         {% if key == 'type' %}
             <unite-cms-core-variants-select input="{{ input_selector }}" content="{{ form_row(child)|escape }}"></unite-cms-core-variants-select>
         {% else %}


### PR DESCRIPTION
…ate over form.children, so we better use form for that