### PR TITLE
Install assets using relative symlinks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,10 +111,10 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "bin/console assets:install --symlink"
+            "bin/console assets:install --symlink --relative"
         ],
         "post-update-cmd": [
-            "bin/console assets:install --symlink"
+            "bin/console assets:install --symlink --relative"
         ]
     }
 }


### PR DESCRIPTION
bin/console assets:install now uses the --relative flag when it's run by the `post-install-cmd` and `post-update-cmd` hooks in composer.json.

This will make the asset symlinked to a relative path rather than an absolute path, which is helpful when running in a docker container with a different filesystem layout to the host, and when transferring UniteCMS between different environments to ensure the same path and version is in use across all locations.