### PR TITLE
fix #673 [CollectionFieldBundle, VariantsFieldBundle]: Only trigger "…

### DIFF
--- a/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
+++ b/src/Bundle/CollectionFieldBundle/Field/Types/CollectionFieldType.php
@@ -342,14 +342,14 @@ class CollectionFieldType extends FieldType implements NestableFieldTypeInterfac
                 }
             }
 
-            // Case 3: row was present in old data but is not present in new data: HARD DELETE
-            if(method_exists($fieldType, 'onHardDelete')) {
+            // Case 3: row was present in old data but is not present in new data: DELETE
+            if(method_exists($fieldType, 'onSoftDelete')) {
                 if(isset($old_data[$field->getIdentifier()])) {
                     foreach ($old_data[$field->getIdentifier()] as $key => $subOldData) {
                         if (!empty($old_data[$field->getIdentifier()][$key]) && empty(
                             $data[$field->getIdentifier()][$key]
                             )) {
-                            $fieldType->onHardDelete($subField, $content, $repository, $subOldData);
+                            $fieldType->onSoftDelete($subField, $content, $repository, $subOldData);
                         }
                     }
                 }

--- a/src/Bundle/CollectionFieldBundle/Tests/NestedCollectionFieldEventHooksTest.php
+++ b/src/Bundle/CollectionFieldBundle/Tests/NestedCollectionFieldEventHooksTest.php
@@ -295,8 +295,8 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         // When deleting a row, nestedFieldType->onDelete should be called
         $this->nestedFieldType->expects($this->never())->method('onCreate');
         $this->nestedFieldType->expects($this->never())->method('onUpdate');
-        $this->nestedFieldType->expects($this->never())->method('onSoftDelete');
-        $this->nestedFieldType->expects($this->exactly(2))->method('onHardDelete')->withConsecutive(
+        $this->nestedFieldType->expects($this->never())->method('onHardDelete');
+        $this->nestedFieldType->expects($this->exactly(2))->method('onSoftDelete')->withConsecutive(
             $this->hParam(['foo' => 'old_value']),
             $this->hParam(['baa' => 'old_value'])
         );
@@ -312,8 +312,8 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         // When deleting a row, nestedFieldType->onDelete should be called
         $this->nestedFieldType->expects($this->never())->method('onCreate');
         $this->nestedFieldType->expects($this->never())->method('onUpdate');
-        $this->nestedFieldType->expects($this->never())->method('onSoftDelete');
-        $this->nestedFieldType->expects($this->exactly(2))->method('onHardDelete')->withConsecutive(
+        $this->nestedFieldType->expects($this->never())->method('onHardDelete');
+        $this->nestedFieldType->expects($this->exactly(2))->method('onSoftDelete')->withConsecutive(
             $this->hParamSetting(['foo' => 'old_value']),
             $this->hParamSetting(['baa' => 'old_value'])
         );
@@ -329,8 +329,8 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         // When deleting a row from the middle of the rows array, nestedFieldType->onDelete should be called only for this one
         $this->nestedFieldType->expects($this->never())->method('onCreate');
         $this->nestedFieldType->expects($this->never())->method('onUpdate');
-        $this->nestedFieldType->expects($this->never())->method('onSoftDelete');
-        $this->nestedFieldType->expects($this->exactly(1))->method('onHardDelete')->withConsecutive(
+        $this->nestedFieldType->expects($this->never())->method('onHardDelete');
+        $this->nestedFieldType->expects($this->exactly(1))->method('onSoftDelete')->withConsecutive(
             $this->hParam(['baa' => 'old_value'])
         );
 
@@ -348,8 +348,8 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         // When deleting a row from the middle of the rows array, nestedFieldType->onDelete should be called only for this one
         $this->nestedFieldType->expects($this->never())->method('onCreate');
         $this->nestedFieldType->expects($this->never())->method('onUpdate');
-        $this->nestedFieldType->expects($this->never())->method('onSoftDelete');
-        $this->nestedFieldType->expects($this->exactly(1))->method('onHardDelete')->withConsecutive(
+        $this->nestedFieldType->expects($this->never())->method('onHardDelete');
+        $this->nestedFieldType->expects($this->exactly(1))->method('onSoftDelete')->withConsecutive(
             $this->hParamSetting(['baa' => 'old_value'])
         );
 
@@ -367,8 +367,8 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         // When deleting a row from the middle of the rows array, nestedFieldType->onDelete should be called only for this one
         $this->nestedFieldType->expects($this->exactly(1))->method('onCreate')->withConsecutive($this->hParam(['row3' => 'value']));
         $this->nestedFieldType->expects($this->exactly(1))->method('onUpdate')->withConsecutive($this->hParam(['foo' => 'baa'], ['foo' => 'new_value']));
-        $this->nestedFieldType->expects($this->never())->method('onSoftDelete');
-        $this->nestedFieldType->expects($this->exactly(1))->method('onHardDelete')->withConsecutive($this->hParam(['luu' => 'old_value']));
+        $this->nestedFieldType->expects($this->never())->method('onHardDelete');
+        $this->nestedFieldType->expects($this->exactly(1))->method('onSoftDelete')->withConsecutive($this->hParam(['luu' => 'old_value']));
 
         $old_data = ['rootCollection' => [
             0 => ['foo' => 'baa'],
@@ -393,8 +393,8 @@ class NestedCollectionFieldEventHooksTest extends TestCase {
         // When deleting a row from the middle of the rows array, nestedFieldType->onDelete should be called only for this one
         $this->nestedFieldType->expects($this->exactly(1))->method('onCreate')->withConsecutive($this->hParamSetting(['row3' => 'value']));
         $this->nestedFieldType->expects($this->exactly(1))->method('onUpdate')->withConsecutive($this->hParamSetting(['foo' => 'baa'], ['foo' => 'new_value']));
-        $this->nestedFieldType->expects($this->never())->method('onSoftDelete');
-        $this->nestedFieldType->expects($this->exactly(1))->method('onHardDelete')->withConsecutive($this->hParamSetting(['luu' => 'old_value']));
+        $this->nestedFieldType->expects($this->never())->method('onHardDelete');
+        $this->nestedFieldType->expects($this->exactly(1))->method('onSoftDelete')->withConsecutive($this->hParamSetting(['luu' => 'old_value']));
 
         $old_data = ['rootCollection' => [
             0 => ['foo' => 'baa'],

--- a/src/Bundle/VariantsFieldBundle/Field/Types/VariantsFieldType.php
+++ b/src/Bundle/VariantsFieldBundle/Field/Types/VariantsFieldType.php
@@ -386,18 +386,18 @@ class VariantsFieldType extends FieldType implements NestableFieldTypeInterface
             return;
         }
 
-        // Case3: Old has variant, but new has not => onHardDelete
+        // Case3: Old has variant, but new has not => onSoftDelete
         if(!empty($old_data[$field->getIdentifier()]['type']) && empty($data[$field->getIdentifier()]['type'])) {
-            $this->onHardDelete($field, $content, $repository, $old_data);
+            $this->onSoftDelete($field, $content, $repository, $old_data);
             return;
         }
 
         // Case4 (A&B): variant identifier in old and new data available.
         if(!empty($old_data[$field->getIdentifier()]['type']) && !empty($data[$field->getIdentifier()]['type'])) {
 
-            // Case 4A: Old had other variant than new data => onHardDelete & onCreate
+            // Case 4A: Old had other variant than new data => onSoftDelete & onCreate
             if($old_data[$field->getIdentifier()]['type'] != $data[$field->getIdentifier()]['type']) {
-                $this->onHardDelete($field, $content, $repository, $old_data);
+                $this->onSoftDelete($field, $content, $repository, $old_data);
                 $this->onCreate($field, $content, $repository, $data);
             }
 

--- a/src/Bundle/VariantsFieldBundle/Tests/NestedFieldEventHooksTest.php
+++ b/src/Bundle/VariantsFieldBundle/Tests/NestedFieldEventHooksTest.php
@@ -237,7 +237,7 @@ class FieldEventHooksTest extends DatabaseAwareTestCase
 
         // Make sure, that delete was fired for variant 1 fields and create for variant 2 fields.
         $this->assertEquals([
-            '$.n1.v1.n2ct1'.Content::class.'hard_delete',
+            '$.n1.v1.n2ct1'.Content::class.'soft_delete',
             '$.n1.v2.n2ct1'.Content::class.'createfoo',
         ], $mock->events);
         $this->assertEquals('foo.onCreate', $content->getData()['n1']['v2']['n2']);
@@ -253,7 +253,7 @@ class FieldEventHooksTest extends DatabaseAwareTestCase
 
         // Make sure, that delete was fired for variant 2 and nothing was fired for variant 1.
         $this->assertEquals([
-            '$.n1.v2.n2ct1'.Content::class.'hard_delete',
+            '$.n1.v2.n2ct1'.Content::class.'soft_delete',
         ], $mock->events);
         $this->assertEquals([], $content->getData()['n1']);
 
@@ -368,7 +368,7 @@ class FieldEventHooksTest extends DatabaseAwareTestCase
 
         // Make sure, that delete was fired for variant 1 fields and create for variant 2 fields.
         $this->assertEquals([
-            '$.n1.v1.n2st1'.Setting::class.'hard_delete',
+            '$.n1.v1.n2st1'.Setting::class.'soft_delete',
             '$.n1.v2.n2st1'.Setting::class.'createfoo',
         ], $mock->events);
         $this->assertEquals('foo.onCreate', $setting->getData()['n1']['v2']['n2']);
@@ -384,7 +384,7 @@ class FieldEventHooksTest extends DatabaseAwareTestCase
 
         // Make sure, that delete was fired for variant 2 and nothing was fired for variant 1.
         $this->assertEquals([
-            '$.n1.v2.n2st1'.Setting::class.'hard_delete',
+            '$.n1.v2.n2st1'.Setting::class.'soft_delete',
         ], $mock->events);
         $this->assertEquals([], $setting->getData()['n1']);
     }


### PR DESCRIPTION
…onSoftDelete" when updating nested fields, to prevent data loose. Even if this means that there could be orphan files