### PR TITLE
Add new ColourPicker field type

### DIFF
--- a/src/Bundle/CoreBundle/Field/Types/ColourPickerFieldType.php
+++ b/src/Bundle/CoreBundle/Field/Types/ColourPickerFieldType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace UniteCMS\CoreBundle\Field\Types;
+
+use UniteCMS\CoreBundle\Field\FieldType;
+use UniteCMS\CoreBundle\Form\ColourPickerType;
+
+class ColourPickerFieldType extends FieldType
+{
+    const TYPE = "colour_picker";
+    const FORM_TYPE = ColourPickerType::class;
+    const SETTINGS = ['description'];
+}

--- a/src/Bundle/CoreBundle/Form/ColourPickerType.php
+++ b/src/Bundle/CoreBundle/Form/ColourPickerType.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace UniteCMS\CoreBundle\Form;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ColourPickerType extends WebComponentType implements DataTransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'unite_cms_colour_picker';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return WebComponentType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        parent::buildForm($builder, $options);
+        $builder->addModelTransformer($this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        parent::buildView($view, $form, $options);
+        $view->vars['assets'] = [
+            [ 'css' => 'main.css', 'package' => 'UniteCMSCoreBundle' ],
+            [ 'js' => 'main.js', 'package' => 'UniteCMSCoreBundle' ],
+        ];
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+        $resolver->setDefaults(
+            [
+                'tag' => 'unite-cms-colour-picker-field',
+                'empty_data' => '',
+                'compound' => false,
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        return $value;
+    }
+}

--- a/src/Bundle/CoreBundle/Resources/config/services.fieldTypes.yml
+++ b/src/Bundle/CoreBundle/Resources/config/services.fieldTypes.yml
@@ -125,3 +125,8 @@ services:
   UniteCMS\CoreBundle\Field\Types\TokenFieldType:
     public: false
     tags: [unite_cms.field_type]
+
+  # Colour Picker Field Type
+  UniteCMS\CoreBundle\Field\Types\ColourPickerFieldType:
+    public: false
+    tags: [unite_cms.field_type]

--- a/src/Bundle/CoreBundle/Resources/webpack/main.js
+++ b/src/Bundle/CoreBundle/Resources/webpack/main.js
@@ -21,6 +21,7 @@ import Link from "./vue/field/Link.vue";
 import Location from "./vue/field/Location.vue";
 import State from "./vue/field/State.vue";
 import AutoText from "./vue/field/AutoText.vue";
+import ColourPicker from "./vue/field/ColourPicker.vue";
 
 import AceDiff from 'ace-diff/dist/ace-diff.min';
 import 'ace-diff/dist/ace-diff.min.css';
@@ -60,6 +61,7 @@ Vue.customElement('unite-cms-core-link-field', Link);
 Vue.customElement('unite-cms-core-location-field', Location);
 Vue.customElement('unite-cms-core-state-field', State);
 Vue.customElement('unite-cms-core-auto-text-field', AutoText);
+Vue.customElement('unite-cms-colour-picker-field', ColourPicker);
 
 // Register views.
 Vue.customElement('unite-cms-core-view-table', TableView);

--- a/src/Bundle/CoreBundle/Resources/webpack/vue/field/ColourPicker.vue
+++ b/src/Bundle/CoreBundle/Resources/webpack/vue/field/ColourPicker.vue
@@ -1,0 +1,154 @@
+<template>
+    <div class="colour-picker" ref="colourpicker">
+        <input type="text" :id="id" :name="name" class="colour-text-input" v-model="colourValue" @focus="showPicker()" @input="updateFromInput" />
+        <span class="colour-picker-container">
+            <span class="current-colour" :style="'background-color: ' + colourValue" @click="togglePicker()"></span>
+            <chrome-picker :value="colours" @input="updateFromPicker" v-if="displayPicker" />
+        </span>
+    </div>
+</template>
+
+<script>
+  import { Chrome } from 'vue-color';
+
+  let defaultColour = '#000000'; // Colour when the value is empty
+
+  export default {
+      data: function () {
+          return {
+              content: this.value,
+              colours: {
+                  hex: defaultColour,
+              },
+              colourValue: '',
+              displayPicker: false,
+          }
+      },
+      mounted() {
+          this.setColour(this.value || defaultColour);
+      },
+      components: {
+          'chrome-picker': Chrome
+      },
+      props: [
+          'value',
+          'id',
+          'name'
+      ],
+      methods: {
+          setColour(colour) {
+              this.updateColours(colour);
+              this.colourValue = colour;
+          },
+          updateColours(colour) {
+              if(colour.slice(0, 1) == '#') {
+                  this.colours = {
+                      hex: colour
+                  };
+              }
+              else if(colour.slice(0, 4) == 'rgba') {
+                  var rgba = colour.replace(/^rgba?\(|\s+|\)$/g,'').split(','),
+                      hex = '#' + ((1 << 24) + (parseInt(rgba[0]) << 16) + (parseInt(rgba[1]) << 8) + parseInt(rgba[2])).toString(16).slice(1);
+                  this.colours = {
+                      hex: hex,
+                      a: rgba[3],
+                  }
+              }
+          },
+          showPicker() {
+              document.addEventListener('click', this.documentClick);
+              this.displayPicker = true;
+          },
+          hidePicker() {
+              document.removeEventListener('click', this.documentClick);
+              this.displayPicker = false;
+          },
+          togglePicker() {
+              this.displayPicker ? this.hidePicker() : this.showPicker();
+          },
+          updateFromInput() {
+              this.updateColours(this.colourValue);
+          },
+          updateFromPicker(colour) {
+              this.colours = colour;
+              if(colour.rgba.a == 1) {
+                  this.colourValue = colour.hex;
+              }
+              else {
+                  this.colourValue = 'rgba(' + colour.rgba.r + ', ' + colour.rgba.g + ', ' + colour.rgba.b + ', ' + colour.rgba.a + ')';
+              }
+          },
+          documentClick(e) {
+              var el = this.$refs.colourpicker,
+                  target = e.target;
+              if(el !== target && !el.contains(target)) {
+                  this.hidePicker()
+              }
+          }
+      },
+      watch: {
+          colourValue(val) {
+              if(val) {
+                  this.updateColours(val);
+                  this.$emit('input', val);
+              }
+          }
+      },
+  }
+</script>
+
+<style lang="scss">
+    .colour-picker {
+        position: relative;
+        width: 229px;
+
+        .colour-text-input {
+            border: 1px solid #ccc;
+            border-radius: 4px 0 0 4px;
+            box-shadow: rgba(0, 0, 0, 0.075) 0px 1px 1px 0px inset;
+            box-sizing: border-box;
+            color: rgb(85, 85, 85);
+            float: left;
+            font-size: 14px;
+            line-height: 20px;
+            padding: 6px 12px;
+            transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+            width: 188px;
+            z-index: 2;
+
+            &:focus {
+                border-color: #66afe9;
+                outline: 0;
+                box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102,175,233,.6);
+            }
+        }
+
+        .colour-picker-container {
+            background-color: rgb(238, 238, 238);
+            border: 1px solid #ccc;
+            border-left: 0;
+            border-radius: 0 4px 4px 0;
+            box-sizing: border-box;
+            display: table-cell;
+            height: 34px;
+            line-height: 14px;
+            padding: 6px 12px;
+            vertical-align: middle;
+            width: 41px;
+        }
+
+        .current-colour {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+        }
+    }
+
+    .vc-chrome {
+        position: absolute;
+        top: 35px;
+        right: 0;
+        z-index: 9;
+    }
+</style>

--- a/src/Bundle/CoreBundle/package.json
+++ b/src/Bundle/CoreBundle/package.json
@@ -18,6 +18,7 @@
     "sass-loader": "^7.0.1",
     "uikit": "^3.1.6",
     "vue": "^2.6.10",
+    "vue-color": "^2.7.0",
     "vue-custom-element": "^3.2.7",
     "vue-loader": "^15.7.1",
     "vue-template-compiler": "^2.6.10",


### PR DESCRIPTION
This feature allows selecting a colour using the Vue component `vue-color`. After selecting the input the picker dropdown will be displayed which allows selection of the colour's hue, saturation and alpha values.

Alternatively the hex code or rgba value can be entered, which is persisted to the database as a string.

For more information about `vue-color`, see http://vue-color.surge.sh