### PR TITLE
Hide Collection's Add Row buttons when max_rows is reached

### DIFF
--- a/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/Collection.vue
+++ b/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/Collection.vue
@@ -8,12 +8,13 @@
                         :prototype="row.prototype"
                         :form-layout="rowFormLayout"
                         :hide-labels="rowLabelHidden"
+                        :should-show-add-row="shouldShowAddRow"
                         @remove="removeRow"
                         @add="addRow"
                 ></unite-cms-collection-field-row>
             </div>
         </div>
-        <div v-if="!maxRows || rows.length < maxRows" class="collection-add-button-wrapper uk-sortable-nodrag">
+        <div v-if="shouldShowAddRow" class="collection-add-button-wrapper uk-sortable-nodrag">
             <a href="#" class="uk-button uk-button-default" v-on:click.prevent="addRow" v-html="feather.icons['plus'].toSvg({ width: 20, height: 20 })"></a>
         </div>
     </div>
@@ -56,6 +57,9 @@
         computed: {
             sortedRows() {
                 return this.rows.sort((a, b) => { return a.position - b.position; });
+            },
+            shouldShowAddRow() {
+                return !this.maxRows || this.rows.length < this.maxRows;
             }
         },
         props: [

--- a/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/CollectionRow.vue
+++ b/src/Bundle/CollectionFieldBundle/Resources/webpack/vue/field/CollectionRow.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div class="collection-add-button-wrapper">
-            <a href="#" class="uk-button uk-button-default" v-on:click.prevent="addRowBefore" v-html="feather.icons['plus'].toSvg({ width: 20, height: 20 })"></a>
+            <a v-if="shouldShowAddRow" href="#" class="uk-button uk-button-default" v-on:click.prevent="addRowBefore" v-html="feather.icons['plus'].toSvg({ width: 20, height: 20 })"></a>
         </div>
         <div class="uk-placeholder uk-padding-small">
             <div class="uk-sortable-handle" v-html="feather.icons['menu'].toSvg({ width: 16, height: 16 })"></div>
@@ -27,7 +27,8 @@
             'delta',
             'prototype',
             'formLayout',
-            'labelHidden'
+            'labelHidden',
+            'shouldShowAddRow', // For toggling addRowBefore button
         ],
         methods: {
             removeRow() {


### PR DESCRIPTION
Currently a collection field only hides the bottom 'Add Row' button when a
collection has reached its `max_rows` count.

This fix makes it hide the top 'Add Row' button and the buttons between
each row when `max_rows` is reached.