### PR TITLE
Constrain modal header width on screens wider than 2100px

### DIFF
--- a/src/Bundle/CoreBundle/Resources/webpack/sass/components/_cards.scss
+++ b/src/Bundle/CoreBundle/Resources/webpack/sass/components/_cards.scss
@@ -160,7 +160,8 @@
 @media (min-width: 2100px) {
   .uk-card.full-content-card {
     &:not(.always-full) {
-      min-width: 1550px;
+      width: 1550px;
+      max-width: 100%;
       align-self: center;
     }
   }


### PR DESCRIPTION
This fix sets a max-width of 100% to prevent the header of a view modal from overflowing horizontally.

This improves the look of the modals as it ensures the close icon is always positioned in the top right corner of the modal, as well as the search input always being visible.

Before:
![before](https://user-images.githubusercontent.com/47307388/63988481-d33e2200-cb1f-11e9-80ec-766f758c0648.png)

After:
![after](https://user-images.githubusercontent.com/47307388/63988502-e224d480-cb1f-11e9-83fd-2cb8bd794791.png)