### PR TITLE
fix #679 #694 [CoreBundle]: readded gedmo loggable

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -15,6 +15,13 @@ doctrine:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
+        mappings:
+            gedmo_loggable:
+                type: annotation
+                prefix: Gedmo\Loggable\Entity
+                dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/lib/Gedmo/Loggable/Entity"
+                alias: GedmoLoggable # (optional) it will default to the name set for the mappingmapping
+                is_bundle: false
         filters:
             gedmo_softdeleteable:
                 class: Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter


### PR DESCRIPTION
gedmo_loggable was removed from the doctrine mappings which resulted in an 500 error. See #679 and #694 
